### PR TITLE
Added components for unwrap vast wrappers

### DIFF
--- a/PlayerCore/action creators/VRMCoreItemSchedulingActionCreator.swift
+++ b/PlayerCore/action creators/VRMCoreItemSchedulingActionCreator.swift
@@ -22,4 +22,12 @@ public extension VRMCore {
     public static func failedItemFetch(originalItem: Item, fetchCandidate: VRMFetchItemQueue.Candidate) -> Action {
         return FetchingError(originalItem: originalItem, fetchCandidate: fetchCandidate)
     }
+    
+    public static func unwrapItem(item: Item, url: URL) -> Action {
+        return UnwrapItem(url: url, item: item)
+    }
+    
+    public static func tooManyIndirections(item: Item) -> Action {
+        return TooManyIndirections(item: item)
+    }
 }

--- a/PlayerCore/actions/VRMCoreItemScheduling.swift
+++ b/PlayerCore/actions/VRMCoreItemScheduling.swift
@@ -32,4 +32,13 @@ extension VRMCore {
         let originalItem: Item
         let fetchCandidate: VRMFetchItemQueue.Candidate
     }
+    
+    struct UnwrapItem: Action {
+        let url: URL
+        let item: Item
+    }
+    
+    struct TooManyIndirections: Action {
+        let item: Item
+    }
 }

--- a/PlayerCore/components/New VRM Core/ScheduledVRMItems.swift
+++ b/PlayerCore/components/New VRM Core/ScheduledVRMItems.swift
@@ -4,16 +4,30 @@
 import Foundation
 
 public struct ScheduledVRMItems {
-    static let initial = ScheduledVRMItems(items: [])
+    static let initial = ScheduledVRMItems(items: [:])
     
-    public let items: Set<VRMCore.Item>
+    public struct Candidate: Hashable {
+        public let id = VRMCore.ID<Candidate>()
+        public let source: VRMCore.Item.Source
+    }
+    
+    public var items: [VRMCore.Item: Set<Candidate>]
 }
 
 func reduce(state: ScheduledVRMItems, action: Action) -> ScheduledVRMItems {
     switch action {
     case let startGroupAction as VRMCore.StartGroupProcessing:
-        let allScheduledItems = state.items.union(startGroupAction.group.items)
-        return ScheduledVRMItems(items: allScheduledItems)
+        var newState = state
+        startGroupAction.group.items.forEach { item in
+            newState.items[item] = Set(arrayLiteral: .init(source:item.source))
+        }
+        return newState
+        
+    case let unwrapAction as VRMCore.UnwrapItem:
+        var newState = state
+        let candidate = ScheduledVRMItems.Candidate(source: .url(unwrapAction.url))
+        newState.items[unwrapAction.item]?.insert(candidate)
+        return newState
     default:
         return state
     }

--- a/PlayerCore/components/New VRM Core/VRMParsingResult.swift
+++ b/PlayerCore/components/New VRM Core/VRMParsingResult.swift
@@ -6,7 +6,12 @@ import Foundation
 public struct VRMParsingResult {
     static let initial = VRMParsingResult(parsedVASTs: [:])
     
-    var parsedVASTs: [VRMCore.Item: VRMCore.VASTModel]
+    public struct Result {
+        public let id = VRMCore.ID<Result>()
+        public let vastModel: VRMCore.VASTModel
+    }
+    
+    public var parsedVASTs: [VRMCore.Item: Result]
 }
 
 func reduce(state: VRMParsingResult, action: Action) -> VRMParsingResult {
@@ -15,22 +20,22 @@ func reduce(state: VRMParsingResult, action: Action) -> VRMParsingResult {
     case let finishParsing as VRMCore.CompleteItemParsing:
         var newState = state
         
-        if let currentVASTModel = newState.parsedVASTs[finishParsing.originalItem] {
+        if let currentVASTModel = newState.parsedVASTs[finishParsing.originalItem]?.vastModel {
             switch(currentVASTModel, finishParsing.vastModel) {
             case let (.wrapper(currentWrapper), .wrapper(processedWrapper)):
                 let mergedWrapper = processedWrapper.merge(with: currentWrapper.pixels,
                                                            and: currentWrapper.adVerifications)
-                newState.parsedVASTs[finishParsing.originalItem] = .wrapper(mergedWrapper)
+                newState.parsedVASTs[finishParsing.originalItem] = .init(vastModel: .wrapper(mergedWrapper))
                 return newState
             case let (.wrapper(currentWrapper), .inline(resultModel)):
                 let mergedResult = resultModel.merge(with: currentWrapper.pixels,
                                                      and: currentWrapper.adVerifications)
-                newState.parsedVASTs[finishParsing.originalItem] = .inline(mergedResult)
+                newState.parsedVASTs[finishParsing.originalItem] = .init(vastModel: .inline(mergedResult))
             case (.inline, _):
                 fatalError("Tried to complete already completed item")
             }
         } else {
-            newState.parsedVASTs[finishParsing.originalItem] = finishParsing.vastModel
+            newState.parsedVASTs[finishParsing.originalItem] = .init(vastModel: finishParsing.vastModel)
         }
         
         return newState

--- a/PlayerCoreTests/Components/ScheduledVRMItemsComponentTest.swift
+++ b/PlayerCoreTests/Components/ScheduledVRMItemsComponentTest.swift
@@ -6,11 +6,32 @@ import XCTest
 
 class ScheduledVRMItemsComponentTest: XCTestCase {
 
-    func testStartFirstGroup() {
-        let group = VRMCore.Group(items: [VRMMockGenerator.createUrlItem(), VRMMockGenerator.createUrlItem()])
+    func testStartGroup() {
+        let urlItem = VRMMockGenerator.createUrlItem()
+        let vastItem = VRMMockGenerator.createVASTItem()
+        let group = VRMCore.Group(items: [urlItem, vastItem])
+        
         var sut = ScheduledVRMItems.initial
         sut = reduce(state: sut, action: PlayerCore.VRMCore.startGroupProcessing(group: group))
+
+        XCTAssertTrue(sut.items[urlItem]?.contains(where: { $0.source == urlItem.source }) == true)
+        XCTAssertTrue(sut.items[vastItem]?.contains(where: { $0.source == vastItem.source }) == true)
         
-        XCTAssertTrue(sut.items.isSubset(of: group.items))
+        let otherUrlItem = VRMMockGenerator.createUrlItem()
+        let nextGroup = VRMCore.Group(items: [otherUrlItem])
+        
+        sut = reduce(state: sut, action: PlayerCore.VRMCore.startGroupProcessing(group: nextGroup))
+        XCTAssertTrue(sut.items[otherUrlItem]?.contains(where: { $0.source == otherUrlItem.source }) == true)
+        
+        XCTAssertEqual(sut.items.count, 3)
+    }
+    
+    func testWrapperProcessing() {
+        let urlItem = VRMMockGenerator.createUrlItem()
+        var sut = ScheduledVRMItems(items: [urlItem: Set(arrayLiteral: ScheduledVRMItems.Candidate(source: urlItem.source))])
+        
+        sut = reduce(state: sut, action: VRMCore.unwrapItem(item: urlItem, url: URL(string: "http://test.com")!))
+        
+        XCTAssertTrue(sut.items[urlItem]?.count == 2)
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Added wrapper actions:
* UnwrapItem
* TooManyIndirections

Added `Result` model in `VRMParsingResult` state
* Each new wrapper updates id of `Result` and set new result by the same key.


<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](https://jira.ouroath.com/browse/OMSDK-2015)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

