### PR TITLE
Refactored VAST model media file and video type

### DIFF
--- a/PlayerCore/action creators/PlayAd.swift
+++ b/PlayerCore/action creators/PlayAd.swift
@@ -5,7 +5,7 @@ import Foundation
 
 public func playAd(model: Ad.VASTModel, id: UUID, isOpenMeasurementEnabled: Bool) -> Action {
     let adCreative: AdCreative? = {
-        if case .mp4(let mediaFile)? = model.videos.first {
+        if let mediaFile = model.mp4MediaFiles.first {
             return AdCreative.mp4(
                 .init(
                     url: mediaFile.url,
@@ -15,7 +15,7 @@ public func playAd(model: Ad.VASTModel, id: UUID, isOpenMeasurementEnabled: Bool
                     scalable: mediaFile.scalable,
                     maintainAspectRatio: mediaFile.maintainAspectRatio))
         }
-        if case .vpaid(let mediaFile)? = model.videos.first {
+        if let mediaFile = model.vpaidMediaFiles.first {
             return AdCreative.vpaid(
                 .init(
                     url: mediaFile.url,

--- a/PlayerCore/action creators/PlayAd.swift
+++ b/PlayerCore/action creators/PlayAd.swift
@@ -5,20 +5,20 @@ import Foundation
 
 public func playAd(model: Ad.VASTModel, id: UUID, isOpenMeasurementEnabled: Bool) -> Action {
     let adCreative: AdCreative? = {
-        if let mp4MediaFile = model.mediaFiles.first(where: { $0.type == .mp4 }) {
+        if case .mp4(let mediaFile)? = model.videos.first {
             return AdCreative.mp4(
                 .init(
-                    url: mp4MediaFile.url,
+                    url: mediaFile.url,
                     clickthrough: model.clickthrough,
                     pixels: model.pixels,
                     id: model.id,
-                    scalable: mp4MediaFile.scalable,
-                    maintainAspectRatio: mp4MediaFile.maintainAspectRatio))
+                    scalable: mediaFile.scalable,
+                    maintainAspectRatio: mediaFile.maintainAspectRatio))
         }
-        if let vpaidMediaFile = model.mediaFiles.first(where: { $0.type == .vpaid }) {
+        if case .vpaid(let mediaFile)? = model.videos.first {
             return AdCreative.vpaid(
                 .init(
-                    url: vpaidMediaFile.url,
+                    url: mediaFile.url,
                     adParameters: model.adParameters,
                     clickthrough: model.clickthrough,
                     pixels: model.pixels,

--- a/PlayerCore/components/AdVASTModel.swift
+++ b/PlayerCore/components/AdVASTModel.swift
@@ -5,7 +5,7 @@ import Foundation
 extension Ad {
     public struct VASTModel: Hashable {
         public let adVerifications: [AdVerification]
-        public let mediaFiles: [MediaFile]
+        public let videos: [VideoType]
         public let clickthrough: URL?
         public let adParameters: String?
         public let pixels: AdPixels
@@ -13,27 +13,35 @@ extension Ad {
         
         public struct MediaFile: Hashable {
             public let url: URL
-            public let type: VideoType
             public let width: Int
             public let height: Int
             public let scalable: Bool
             public let maintainAspectRatio: Bool
             
             public init(url: URL,
-                        type: VideoType,
                         width: Int,
                         height: Int,
                         scalable: Bool,
                         maintainAspectRatio: Bool) {
                 self.url = url
-                self.type = type
                 self.width = width
                 self.height = height
                 self.scalable = scalable
                 self.maintainAspectRatio = maintainAspectRatio
             }
-            public enum VideoType { case mp4, vpaid }
         }
+        public enum VideoType: Hashable {
+            case mp4(MediaFile)
+            case vpaid(MediaFile)
+            
+            public var url: URL {
+                switch self {
+                case .mp4(let mediaFile): return mediaFile.url
+                case .vpaid(let mediaFile): return mediaFile.url
+                }
+            }
+        }
+        
         public struct AdVerification: Hashable {
             public let vendorKey: String?
             public let javaScriptResource: URL
@@ -51,13 +59,13 @@ extension Ad {
             }
         }
         public init(adVerifications: [AdVerification],
-                    mediaFiles: [MediaFile],
+                    videos: [VideoType],
                     clickthrough: URL?,
                     adParameters: String?,
                     pixels: AdPixels,
                     id: String?) {
             self.adVerifications = adVerifications
-            self.mediaFiles = mediaFiles
+            self.videos = videos
             self.clickthrough = clickthrough
             self.adParameters = adParameters
             self.pixels = pixels

--- a/PlayerCore/components/AdVASTModel.swift
+++ b/PlayerCore/components/AdVASTModel.swift
@@ -5,13 +5,14 @@ import Foundation
 extension Ad {
     public struct VASTModel: Hashable {
         public let adVerifications: [AdVerification]
-        public let videos: [VideoType]
+        public let mp4MediaFiles: [MP4MediaFile]
+        public let vpaidMediaFiles: [VPAIDMediaFile]
         public let clickthrough: URL?
         public let adParameters: String?
         public let pixels: AdPixels
         public let id: String?
         
-        public struct MediaFile: Hashable {
+        public struct MP4MediaFile: Hashable {
             public let url: URL
             public let width: Int
             public let height: Int
@@ -30,15 +31,17 @@ extension Ad {
                 self.maintainAspectRatio = maintainAspectRatio
             }
         }
-        public enum VideoType: Hashable {
-            case mp4(MediaFile)
-            case vpaid(MediaFile)
+        public struct VPAIDMediaFile: Hashable {
+            public let url: URL
+            public let scalable: Bool
+            public let maintainAspectRatio: Bool
             
-            public var url: URL {
-                switch self {
-                case .mp4(let mediaFile): return mediaFile.url
-                case .vpaid(let mediaFile): return mediaFile.url
-                }
+            public init(url: URL,
+                        scalable: Bool,
+                        maintainAspectRatio: Bool) {
+                self.url = url
+                self.scalable = scalable
+                self.maintainAspectRatio = maintainAspectRatio
             }
         }
         
@@ -59,13 +62,15 @@ extension Ad {
             }
         }
         public init(adVerifications: [AdVerification],
-                    videos: [VideoType],
+                    mp4MediaFiles: [MP4MediaFile],
+                    vpaidMediaFiles: [VPAIDMediaFile],
                     clickthrough: URL?,
                     adParameters: String?,
                     pixels: AdPixels,
                     id: String?) {
             self.adVerifications = adVerifications
-            self.videos = videos
+            self.mp4MediaFiles = mp4MediaFiles
+            self.vpaidMediaFiles = vpaidMediaFiles
             self.clickthrough = clickthrough
             self.adParameters = adParameters
             self.pixels = pixels

--- a/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
+++ b/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
@@ -39,7 +39,8 @@ public extension Ad.VASTModel {
     public func merge(with pixels: AdPixels, and verifications: [Ad.VASTModel.AdVerification]) -> Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
-            videos: videos,
+            mp4MediaFiles: mp4MediaFiles,
+            vpaidMediaFiles: vpaidMediaFiles,
             clickthrough: clickthrough,
             adParameters: adParameters,
             pixels: self.pixels.merge(with: pixels),

--- a/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
+++ b/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
@@ -39,7 +39,7 @@ public extension Ad.VASTModel {
     public func merge(with pixels: AdPixels, and verifications: [Ad.VASTModel.AdVerification]) -> Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
-            mediaFiles: mediaFiles,
+            videos: videos,
             clickthrough: clickthrough,
             adParameters: adParameters,
             pixels: self.pixels.merge(with: pixels),

--- a/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
@@ -116,7 +116,7 @@ class AdVRMManagerComponentTestCase: XCTestCase {
         
         sut = reduce(state: sut, action: VRMItem.model(.init(adId: "adId",
                                                              info: emptyMetaInfo,
-                                                             model: .model(with: [.mp4(with: testUrl)]),
+                                                             model: .model(with: [.mp4Ad(with: testUrl)]),
                                                              requestDate: requestDate,
                                                              responseDate: responseDate)))
         if case .finish(let request) = sut.request.state {
@@ -134,7 +134,7 @@ class AdVRMManagerComponentTestCase: XCTestCase {
         sut.request.timeout = .afterHard
         sut = reduce(state: sut, action: VRMItem.model(.init(adId: "adId",
                                                              info: emptyMetaInfo,
-                                                             model: .model(with: [.mp4(with: testUrl)]), 
+                                                             model: .model(with: [.mp4Ad(with: testUrl)]),
                                                              requestDate: requestDate,
                                                              responseDate: responseDate)))
         if case .finish(let request) = sut.request.state {

--- a/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
@@ -116,7 +116,7 @@ class AdVRMManagerComponentTestCase: XCTestCase {
         
         sut = reduce(state: sut, action: VRMItem.model(.init(adId: "adId",
                                                              info: emptyMetaInfo,
-                                                             model: .model(with: [.mp4Ad(with: testUrl)]),
+                                                             model: .model(withVpaid: [], andMp4: [.video(with: testUrl)]),
                                                              requestDate: requestDate,
                                                              responseDate: responseDate)))
         if case .finish(let request) = sut.request.state {
@@ -134,7 +134,7 @@ class AdVRMManagerComponentTestCase: XCTestCase {
         sut.request.timeout = .afterHard
         sut = reduce(state: sut, action: VRMItem.model(.init(adId: "adId",
                                                              info: emptyMetaInfo,
-                                                             model: .model(with: [.mp4Ad(with: testUrl)]),
+                                                             model: .model(withVpaid: [], andMp4: [.video(with: testUrl)]),
                                                              requestDate: requestDate,
                                                              responseDate: responseDate)))
         if case .finish(let request) = sut.request.state {

--- a/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
@@ -36,7 +36,7 @@ class VRMParsingResultComponentTest: XCTestCase {
                                                      pixels: AdPixels(impression: [impression1]))
         
         let adVAST = Ad.VASTModel(adVerifications: [],
-                                  mediaFiles: [],
+                                  videos: [],
                                   clickthrough: nil,
                                   adParameters: nil,
                                   pixels: AdPixels(),
@@ -85,7 +85,7 @@ class VRMParsingResultComponentTest: XCTestCase {
         var sut = VRMParsingResult(parsedVASTs: [urlItem: initialResult])
         
         let adVAST = Ad.VASTModel(adVerifications: [adVerification3],
-                                  mediaFiles: [],
+                                  videos: [],
                                   clickthrough: nil,
                                   adParameters: nil,
                                   pixels: AdPixels(impression: [impression3]),

--- a/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
@@ -36,7 +36,8 @@ class VRMParsingResultComponentTest: XCTestCase {
                                                      pixels: AdPixels(impression: [impression1]))
         
         let adVAST = Ad.VASTModel(adVerifications: [],
-                                  videos: [],
+                                  mp4MediaFiles: [],
+                                  vpaidMediaFiles: [],
                                   clickthrough: nil,
                                   adParameters: nil,
                                   pixels: AdPixels(),
@@ -85,7 +86,8 @@ class VRMParsingResultComponentTest: XCTestCase {
         var sut = VRMParsingResult(parsedVASTs: [urlItem: initialResult])
         
         let adVAST = Ad.VASTModel(adVerifications: [adVerification3],
-                                  videos: [],
+                                  mp4MediaFiles: [],
+                                  vpaidMediaFiles: [],
                                   clickthrough: nil,
                                   adParameters: nil,
                                   pixels: AdPixels(impression: [impression3]),

--- a/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
+++ b/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
@@ -8,7 +8,7 @@ class VRMProcessingResultComponentTests: XCTestCase {
     
     func testReducer() {
         let inlineVAST = Ad.VASTModel(adVerifications: [],
-                                      mediaFiles: [],
+                                      videos: [],
                                       clickthrough: nil,
                                       adParameters: nil,
                                       pixels: AdPixels(),

--- a/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
+++ b/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
@@ -8,7 +8,8 @@ class VRMProcessingResultComponentTests: XCTestCase {
     
     func testReducer() {
         let inlineVAST = Ad.VASTModel(adVerifications: [],
-                                      videos: [],
+                                      mp4MediaFiles: [],
+                                      vpaidMediaFiles: [],
                                       clickthrough: nil,
                                       adParameters: nil,
                                       pixels: AdPixels(),

--- a/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
+++ b/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
@@ -6,8 +6,8 @@ import XCTest
 
 class PlayAdActionCreatorTestCase: XCTestCase {
     func testWithMp4MediaFile() {
-        let mediaFiles = [Ad.VASTModel.VideoType.mp4Ad(with: testUrl)]
-        let model = Ad.VASTModel.model(with: mediaFiles)
+        let mediaFiles = [Ad.VASTModel.MP4MediaFile.video(with: testUrl)]
+        let model = Ad.VASTModel.model(withVpaid: [], andMp4: mediaFiles)
         guard let action = PlayerCore.playAd(model: model,
                                              id: UUID(),
                                              isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
@@ -15,8 +15,8 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
     
     func testWithVPAIDMediaFile() {
-        let mediaFiles = [Ad.VASTModel.VideoType.vpaidAd(with: testUrl)]
-        let model = Ad.VASTModel.model(with: mediaFiles)
+        let mediaFiles = [Ad.VASTModel.VPAIDMediaFile.video(with: testUrl)]
+        let model = Ad.VASTModel.model(withVpaid: mediaFiles, andMp4: [])
         guard let action = PlayerCore.playAd(model: model,
                                              id: UUID(),
                                              isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
@@ -24,9 +24,9 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
     
     func testWithMp4AndVPAIDMediafile() {
-        let mediaFiles = [Ad.VASTModel.VideoType.mp4Ad(with: testUrl),
-                          Ad.VASTModel.VideoType.vpaidAd(with: testUrl)]
-        let model = Ad.VASTModel.model(with: mediaFiles)
+        let mp4MediaFiles = [Ad.VASTModel.MP4MediaFile.video(with: testUrl)]
+        let vpaidMediaFiles = [Ad.VASTModel.VPAIDMediaFile.video(with: testUrl)]
+        let model = Ad.VASTModel.model(withVpaid: vpaidMediaFiles, andMp4: mp4MediaFiles)
         do {
             guard let action = PlayerCore.playAd(model: model,
                                                  id: UUID(),
@@ -42,28 +42,30 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
 }
 
-extension Ad.VASTModel.VideoType {
-    static func mp4Ad(with url: URL) -> Ad.VASTModel.VideoType {
-        return .mp4(Ad.VASTModel.MediaFile(url: url,
-                         width: 300,
-                         height: 400,
-                         scalable: false,
-                         maintainAspectRatio: true))
+extension Ad.VASTModel.MP4MediaFile {
+    static func video(with url: URL) -> Ad.VASTModel.MP4MediaFile {
+        return Ad.VASTModel.MP4MediaFile(url: url,
+                                         width: 300,
+                                         height: 400,
+                                         scalable: false,
+                                         maintainAspectRatio: true)
     }
-    static func vpaidAd(with url: URL) -> Ad.VASTModel.VideoType {
-        return .vpaid(Ad.VASTModel.MediaFile(url: url,
-                         width: 300,
-                         height: 400,
-                         scalable: false,
-                         maintainAspectRatio: true))
+}
+extension Ad.VASTModel.VPAIDMediaFile {
+    static func video(with url: URL) -> Ad.VASTModel.VPAIDMediaFile {
+        return Ad.VASTModel.VPAIDMediaFile(url: url,
+                                           scalable: false,
+                                           maintainAspectRatio: true)
     }
 }
 
 extension Ad.VASTModel {
-    static func model(with videos: [Ad.VASTModel.VideoType]) -> Ad.VASTModel  {
+    static func model(withVpaid vpaid: [Ad.VASTModel.VPAIDMediaFile],
+                      andMp4 mp4: [Ad.VASTModel.MP4MediaFile]) -> Ad.VASTModel  {
         return Ad.VASTModel(
             adVerifications: [],
-            videos: videos,
+            mp4MediaFiles: mp4,
+            vpaidMediaFiles: vpaid,
             clickthrough: nil,
             adParameters: nil,
             pixels: AdPixels(impression: [],

--- a/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
+++ b/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class PlayAdActionCreatorTestCase: XCTestCase {
     func testWithMp4MediaFile() {
-        let mediaFiles = [Ad.VASTModel.MediaFile.mp4(with: testUrl)]
+        let mediaFiles = [Ad.VASTModel.VideoType.mp4Ad(with: testUrl)]
         let model = Ad.VASTModel.model(with: mediaFiles)
         guard let action = PlayerCore.playAd(model: model,
                                              id: UUID(),
@@ -15,7 +15,7 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
     
     func testWithVPAIDMediaFile() {
-        let mediaFiles = [Ad.VASTModel.MediaFile.vpaid(with: testUrl)]
+        let mediaFiles = [Ad.VASTModel.VideoType.vpaidAd(with: testUrl)]
         let model = Ad.VASTModel.model(with: mediaFiles)
         guard let action = PlayerCore.playAd(model: model,
                                              id: UUID(),
@@ -24,8 +24,8 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
     
     func testWithMp4AndVPAIDMediafile() {
-        let mediaFiles = [Ad.VASTModel.MediaFile.mp4(with: testUrl),
-                          Ad.VASTModel.MediaFile.vpaid(with: testUrl)]
+        let mediaFiles = [Ad.VASTModel.VideoType.mp4Ad(with: testUrl),
+                          Ad.VASTModel.VideoType.vpaidAd(with: testUrl)]
         let model = Ad.VASTModel.model(with: mediaFiles)
         do {
             guard let action = PlayerCore.playAd(model: model,
@@ -42,30 +42,28 @@ class PlayAdActionCreatorTestCase: XCTestCase {
     }
 }
 
-extension Ad.VASTModel.MediaFile {
-    static func mp4(with url: URL) -> Ad.VASTModel.MediaFile {
-        return Ad.VASTModel.MediaFile(url: url,
-                         type: .mp4,
+extension Ad.VASTModel.VideoType {
+    static func mp4Ad(with url: URL) -> Ad.VASTModel.VideoType {
+        return .mp4(Ad.VASTModel.MediaFile(url: url,
                          width: 300,
                          height: 400,
                          scalable: false,
-                         maintainAspectRatio: true)
+                         maintainAspectRatio: true))
     }
-    static func vpaid(with url: URL) -> Ad.VASTModel.MediaFile {
-        return Ad.VASTModel.MediaFile(url: url,
-                         type: .vpaid,
+    static func vpaidAd(with url: URL) -> Ad.VASTModel.VideoType {
+        return .vpaid(Ad.VASTModel.MediaFile(url: url,
                          width: 300,
                          height: 400,
                          scalable: false,
-                         maintainAspectRatio: true)
+                         maintainAspectRatio: true))
     }
 }
 
 extension Ad.VASTModel {
-    static func model(with mediaFiles: [Ad.VASTModel.MediaFile]) -> Ad.VASTModel  {
+    static func model(with videos: [Ad.VASTModel.VideoType]) -> Ad.VASTModel  {
         return Ad.VASTModel(
             adVerifications: [],
-            mediaFiles: mediaFiles,
+            videos: videos,
             clickthrough: nil,
             adParameters: nil,
             pixels: AdPixels(impression: [],


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Main changes are in `VASTModel.swift` file. These changes are done to remove `VideoType` enum from `MediaFiles` structure and instead to make two structures for mp4 and vpaid media files.
```
Ad -> VASTModel -> Mp4MediaFile(width, height...) 
                -> VpaidMediaFile(width, height...)
```
- WT pass the same as before.

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

