### PR TITLE
enum VRMRequest -> struct VRMRequest

### DIFF
--- a/PlayerCore/components/New VRM Core/VRMRequestStatus.swift
+++ b/PlayerCore/components/New VRM Core/VRMRequestStatus.swift
@@ -3,22 +3,22 @@
 import Foundation
 
 public struct VRMRequestStatus {
-    static let initial = VRMRequestStatus(request: .none, requestsFired: 0)
+    static let initial = VRMRequestStatus(request: nil, requestsFired: 0)
     
-    public enum Request {
-        case none
-        case request(url: URL, id: UUID)
+    public struct Request {
+        public let url: URL
+        public let id: UUID
     }
     
-    public let request: Request
+    public let request: Request?
     public let requestsFired: Int
 }
 
 func reduce(state: VRMRequestStatus, action: Action) -> VRMRequestStatus {
     switch action {
     case let adRequest as VRMCore.AdRequest:
-        return VRMRequestStatus(request: .request(url: adRequest.url,
-                                                  id: adRequest.id),
+        return VRMRequestStatus(request: .init(url: adRequest.url,
+                                                id: adRequest.id),
                                 requestsFired: state.requestsFired+1)
     default:
         return state

--- a/PlayerCoreTests/Components/VRMRequestStatusComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMRequestStatusComponentTest.swift
@@ -13,9 +13,9 @@ class VRMRequestStatusComponentTest: XCTestCase {
         let sut = reduce(state: initial, action: VRMCore.adRequest(url: url, id: uuid, type: .preroll))
         
         XCTAssertEqual(sut.requestsFired, 1)
-        if case let .request(requestUrl, id) = sut.request {
-            XCTAssertEqual(id, uuid)
-            XCTAssertEqual(requestUrl, url)
+        if let request = sut.request {
+            XCTAssertEqual(request.id, uuid)
+            XCTAssertEqual(request.url, url)
         } else {
             XCTFail()
         }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Replaced `enum` VRMRequest with `struct` because it repeats optional implementation

<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](https://jira.ouroath.com/browse/OMSDK-2184)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

