### PR TITLE
Moved isOpenMeasurementAllowed from playAd action to State init

### DIFF
--- a/PlayerCore/OpenMeasurement.swift
+++ b/PlayerCore/OpenMeasurement.swift
@@ -27,9 +27,6 @@ public enum OpenMeasurement {
 func reduce(state: OpenMeasurement, action: Action) -> OpenMeasurement {
     switch action {
     case let action as ShowAd where state != .disabled:
-        guard action.isOpenMeasurementEnabled else {
-            return .disabled
-        }
         guard action.adVerifications.isEmpty == false else {
             return .inactive
         }

--- a/PlayerCore/action creators/PlayAd.swift
+++ b/PlayerCore/action creators/PlayAd.swift
@@ -10,7 +10,7 @@ public func showVPAIDAd(creative: AdCreative.VPAID, id: UUID) -> Action {
     return ShowVPAIDAd(creative: creative, id: id)
 }
 
-public func playAd(model: Ad.VASTModel, id: UUID, isOpenMeasurementEnabled: Bool) -> Action {
+public func playAd(model: Ad.VASTModel, id: UUID) -> Action {
     let adCreative: AdCreative? = {
         if let mediaFile = model.mp4MediaFiles.first {
             return AdCreative.mp4(
@@ -38,6 +38,5 @@ public func playAd(model: Ad.VASTModel, id: UUID, isOpenMeasurementEnabled: Bool
     guard let creative = adCreative else { return SkipAd(id: id) }
     return ShowAd(creative: creative,
                   id: id,
-                  adVerifications: model.adVerifications,
-                  isOpenMeasurementEnabled: isOpenMeasurementEnabled)
+                  adVerifications: model.adVerifications)
 }

--- a/PlayerCore/actions/ShowAdAction.swift
+++ b/PlayerCore/actions/ShowAdAction.swift
@@ -7,7 +7,6 @@ struct ShowAd: Action {
     let creative: AdCreative
     let id: UUID
     let adVerifications: [Ad.VASTModel.AdVerification]
-    let isOpenMeasurementEnabled: Bool
 }
 
 struct ShowMP4Ad: Action {

--- a/PlayerCore/components/AdCreative.swift
+++ b/PlayerCore/components/AdCreative.swift
@@ -83,6 +83,8 @@ func reduce(state: AdCreative, action: Action) -> AdCreative {
             return .vpaid(vpaidAdCreatives)
         }
         return .none
+    case let action as ShowAd:
+        return action.creative
     case is VRMCore.AdRequest:
         return .none
     default: return state

--- a/PlayerCore/components/State.swift
+++ b/PlayerCore/components/State.swift
@@ -64,7 +64,8 @@ extension State {
                 hasPrerollAds: Bool,
                 midrolls: [Midroll],
                 timeoutBarrier: Double,
-                maxAdDuration: Int) {
+                maxAdDuration: Int,
+                isOpenMeasurementEnabled: Bool) {
         self = State(
             playlist: Playlist(currentIndex: 0),
             rate: Rate(contentRate: Rate.Value(player: isPlaybackInitiated, stream: false),
@@ -83,7 +84,7 @@ extension State {
                                  startAdSession: nil,
                                  allowedDuration: Double(maxAdDuration)),
             selectedAdCreative: .none,
-            openMeasurement: OpenMeasurement.inactive,
+            openMeasurement: isOpenMeasurementEnabled ? .inactive : .disabled,
             serviceScript: OpenMeasurementServiceScript.none,
             currentTime: CurrentTime(content: nil, ad: CMTime.zero),
             loadedTimeRanges: LoadedTimeRanges(content: [] as [CMTimeRange], ad: [] as [CMTimeRange]),

--- a/PlayerCoreTests/Components/AdComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdComponentTestCase.swift
@@ -36,7 +36,7 @@ class AdComponentTestCase: XCTestCase {
                          vpaidAdCreative: nil,
                          currentAd: .empty,
                          currentType: .preroll)
-        let sut = reduce(state: initial, action: ShowAd(creative: .mp4([mp4AdCreative]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        let sut = reduce(state: initial, action: ShowAd(creative: .mp4([mp4AdCreative]), id: UUID(), adVerifications: []))
         XCTAssertNil(sut.vpaidAdCreative)
         XCTAssertEqual(mp4AdCreative, sut.mp4AdCreative)
         XCTAssertEqual(sut.currentAd, .play)
@@ -51,7 +51,7 @@ class AdComponentTestCase: XCTestCase {
                          vpaidAdCreative: nil,
                          currentAd: .empty,
                          currentType: .midroll)
-        let sut = reduce(state: initial, action: ShowAd(creative: .vpaid([vpaidAdCreative]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        let sut = reduce(state: initial, action: ShowAd(creative: .vpaid([vpaidAdCreative]), id: UUID(), adVerifications: []))
         XCTAssertNil(sut.mp4AdCreative)
         XCTAssertEqual(vpaidAdCreative, sut.vpaidAdCreative)
         XCTAssertEqual(sut.currentAd, .play)

--- a/PlayerCoreTests/Components/AdFinishTrackerComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdFinishTrackerComponentTestCase.swift
@@ -9,7 +9,7 @@ class AdFinishTrackerComponentTestCase: XCTestCase {
         let initial = AdFinishTracker(isForceFinished: true, isSuccessfullyCompleted: true)
         let sut = reduce(state: initial,
                          action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
-                                        id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+                                        id: UUID(), adVerifications: []))
         XCTAssertFalse(sut.isForceFinished)
         XCTAssertFalse(sut.isSuccessfullyCompleted)
     }

--- a/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdVRMManagerComponentTestCase.swift
@@ -65,7 +65,7 @@ class AdVRMManagerComponentTestCase: XCTestCase {
                                request: .init(id: id,
                                               timeout: .afterHard,
                                               state: .finish(defaultFinish)))
-        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.request.id, id)
         XCTAssertEqual(sut.request.timeout, .afterHard)
         guard case .finish = sut.request.state else { return XCTFail("Expecting `ready` state here!") }

--- a/PlayerCoreTests/Components/CurrentTimeComponentTestCase.swift
+++ b/PlayerCoreTests/Components/CurrentTimeComponentTestCase.swift
@@ -50,7 +50,7 @@ class CurrentTimeComponentTestCase: XCTestCase {
     }
     
     func testReduceOnShowAd() {
-        let sut = reduce(state: initial, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        let sut = reduce(state: initial, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.content?.time, 5 |> toCMTime)
         XCTAssertEqual(sut.ad, CMTime.zero)
     }

--- a/PlayerCoreTests/Components/InteractiveSeekingTestCaseComponent.swift
+++ b/PlayerCoreTests/Components/InteractiveSeekingTestCaseComponent.swift
@@ -26,8 +26,7 @@ class InteractiveSeekingTestCaseComponent: XCTestCase {
     func testReduceOnShowAd() {
         let sut = reduce(state: initial, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                         id: UUID(),
-                                                        adVerifications: [],
-                                                        isOpenMeasurementEnabled: true))
+                                                        adVerifications: []))
         XCTAssertEqual(sut.isSeekingInProgress, false)
     }
     

--- a/PlayerCoreTests/Components/LoadedTimeRangesComponentTestCase.swift
+++ b/PlayerCoreTests/Components/LoadedTimeRangesComponentTestCase.swift
@@ -47,7 +47,7 @@ class LoadedTimeRangesComponentTestCase: XCTestCase {
     
     func testShowAd() {
         let sut = reduce(state: initial,
-                         action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+                         action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.ad.count, 0)
         XCTAssertEqual(sut.content.count, 1)
         XCTAssertEqual(sut.content[0].start, (0, 0) |> toCMTime)

--- a/PlayerCoreTests/Components/MuteComponentTestCase.swift
+++ b/PlayerCoreTests/Components/MuteComponentTestCase.swift
@@ -38,8 +38,7 @@ class SoundComponentTestCase: XCTestCase {
         let initial = Mute(player: false, vpaid: true)
         let action = ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]),
                             id: UUID(),
-                            adVerifications: [],
-                            isOpenMeasurementEnabled: true)
+                            adVerifications: [])
         let sut = reduce(state: initial, action: action)
         XCTAssertEqual(sut.player, false)
         XCTAssertEqual(sut.vpaid, false)

--- a/PlayerCoreTests/Components/OpenMeasurementComponentTestCase.swift
+++ b/PlayerCoreTests/Components/OpenMeasurementComponentTestCase.swift
@@ -19,8 +19,7 @@ class OpenMeasurementComponentTestCase: XCTestCase {
     func testDefaultBehavior() {
         sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                 id: UUID(),
-                                                adVerifications: adVerifications,
-                                                isOpenMeasurementEnabled: true))
+                                                adVerifications: adVerifications))
         XCTAssertEqual(sut, .loading(adVerifications))
         
         sut = reduce(state: sut, action: OpenMeasurementActivated(adEvents: .empty, videoEvents: .empty))
@@ -35,15 +34,13 @@ class OpenMeasurementComponentTestCase: XCTestCase {
     func testAdVerificationNotParsed() {
         sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                 id: UUID(),
-                                                adVerifications: [],
-                                                isOpenMeasurementEnabled: true))
+                                                adVerifications: []))
         XCTAssertEqual(sut, .inactive)
     }
     func testFailedMeasurement() {
         sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                 id: UUID(),
-                                                adVerifications: adVerifications,
-                                                isOpenMeasurementEnabled: true))
+                                                adVerifications: adVerifications))
         sut = reduce(state: sut, action: OpenMeasurementActivated(adEvents: .empty, videoEvents: .empty))
         XCTAssertTrue(sut.isActive)
         
@@ -52,16 +49,15 @@ class OpenMeasurementComponentTestCase: XCTestCase {
         
         sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                 id: UUID(),
-                                                adVerifications: adVerifications,
-                                                isOpenMeasurementEnabled: true))
+                                                adVerifications: adVerifications))
         sut = reduce(state: sut, action: OpenMeasurementConfigurationFailed(error: Failed()))
         XCTAssertTrue(sut.isFailed)
     }
     func testReduceWithDisabledOM() {
+        sut = .disabled
         sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]),
                                                 id: UUID(),
-                                                adVerifications: adVerifications,
-                                                isOpenMeasurementEnabled: false))
+                                                adVerifications: adVerifications))
         XCTAssertEqual(sut, .disabled)
         
         sut = reduce(state: sut, action: ShowContent())

--- a/PlayerCoreTests/Components/PlaylistComponentTestCase.swift
+++ b/PlayerCoreTests/Components/PlaylistComponentTestCase.swift
@@ -19,7 +19,7 @@ class PlaylistComponentTestCase: XCTestCase {
         sut = reduce(state: initial, action: SelectVideoAtIdx(idx: 1, id: .init(), hasPrerollAds: false, midrolls: []))
         XCTAssertEqual(sut.currentIndex, 1)
         
-        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.currentIndex, 1)
     }
 }

--- a/PlayerCoreTests/Components/RateComponentTestCase.swift
+++ b/PlayerCoreTests/Components/RateComponentTestCase.swift
@@ -68,7 +68,7 @@ class RateComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.isAttachedToViewPort, false)
         XCTAssertEqual(sut.currentKind, .content)
         
-        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         
         XCTAssertEqual(sut.contentRate.player, false)
         XCTAssertEqual(sut.contentRate.stream, false)
@@ -77,7 +77,7 @@ class RateComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.isAttachedToViewPort, false)
         XCTAssertEqual(sut.currentKind, .ad)
         
-        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         
         XCTAssertEqual(sut.contentRate.player, false)
         XCTAssertEqual(sut.contentRate.stream, false)
@@ -186,7 +186,7 @@ class RateComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.isAttachedToViewPort, true)
         XCTAssertEqual(sut.currentKind, .content)
         
-        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .mp4([AdCreative.mp4(with: testUrl)]), id: UUID(), adVerifications: []))
         sut = reduce(state: sut, action: AdDidPause())
         
         XCTAssertEqual(sut.contentRate.player, false)
@@ -196,7 +196,7 @@ class RateComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.isAttachedToViewPort, true)
         XCTAssertEqual(sut.currentKind, .ad)
         
-        sut = reduce(state: sut, action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: sut, action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: []))
         sut = reduce(state: sut, action: AdPaused())
         XCTAssertEqual(sut.contentRate.player, false)
         XCTAssertEqual(sut.contentRate.stream, false)

--- a/PlayerCoreTests/Components/VPAIDStateComponentTestCase.swift
+++ b/PlayerCoreTests/Components/VPAIDStateComponentTestCase.swift
@@ -8,10 +8,10 @@ class VPAIDStateComponentTestCase: XCTestCase {
     let initial = VPAIDState(events: [], adClickthrough: nil)
     
     func testOnShowAdAction() {
-        var sut = reduce(state: initial, action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        var sut = reduce(state: initial, action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.adClickthrough, testUrl)
         
-        sut = reduce(state: VPAIDState(events: [.AdSkipped], adClickthrough: nil), action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: [], isOpenMeasurementEnabled: true))
+        sut = reduce(state: VPAIDState(events: [.AdSkipped], adClickthrough: nil), action: ShowAd(creative: .vpaid([AdCreative.vpaid(with: testUrl)]), id: UUID(), adVerifications: []))
         XCTAssertEqual(sut.adClickthrough, testUrl)
         XCTAssert(sut.events.isEmpty)
     }

--- a/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
+++ b/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
@@ -9,8 +9,7 @@ class PlayAdActionCreatorTestCase: XCTestCase {
         let mediaFiles = [Ad.VASTModel.MP4MediaFile.video(with: testUrl)]
         let model = Ad.VASTModel.model(withMp4: mediaFiles, andVpaid: [])
         guard let action = PlayerCore.playAd(model: model,
-                                             id: UUID(),
-                                             isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
+                                             id: UUID()) as? ShowAd else { return XCTFail() }
         guard case .mp4(_) = action.creative else { return XCTFail() }
     }
     
@@ -18,8 +17,7 @@ class PlayAdActionCreatorTestCase: XCTestCase {
         let mediaFiles = [Ad.VASTModel.VPAIDMediaFile.video(with: testUrl)]
         let model = Ad.VASTModel.model(withMp4: [], andVpaid: mediaFiles)
         guard let action = PlayerCore.playAd(model: model,
-                                             id: UUID(),
-                                             isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
+                                             id: UUID()) as? ShowAd else { return XCTFail() }
         guard case .vpaid(_) = action.creative else { return XCTFail() }
     }
     
@@ -29,14 +27,12 @@ class PlayAdActionCreatorTestCase: XCTestCase {
         let model = Ad.VASTModel.model(withMp4: mp4MediaFiles, andVpaid: vpaidMediaFiles)
         do {
             guard let action = PlayerCore.playAd(model: model,
-                                                 id: UUID(),
-                                                 isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
+                                                 id: UUID()) as? ShowAd else { return XCTFail() }
             guard case .mp4(_) = action.creative else { return XCTFail() }
         }
         do {
             guard let action = PlayerCore.playAd(model: model,
-                                                 id: UUID(),
-                                                 isOpenMeasurementEnabled: true) as? ShowAd else { return XCTFail() }
+                                                 id: UUID()) as? ShowAd else { return XCTFail() }
             guard case .mp4(_) = action.creative else { return XCTFail() }
         }
     }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Removed open measurement feature toggle value from playAd action.

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


