### PR TITLE
Added internal id for AdCreative

### DIFF
--- a/PlayerCore/components/AdCreative.swift
+++ b/PlayerCore/components/AdCreative.swift
@@ -6,6 +6,7 @@ public enum AdCreative: Hashable {
     case mp4([MP4]), vpaid([VPAID]), none
     
     public struct MP4: Hashable {
+        public let internalID: UUID
         public let url: URL
         public let clickthrough: URL?
         public let pixels: AdPixels
@@ -15,14 +16,16 @@ public enum AdCreative: Hashable {
         public let scalable: Bool
         public let maintainAspectRatio: Bool
         
-        public init(url: URL,
-                    clickthrough: URL?,
-                    pixels: AdPixels,
-                    id: String?,
-                    width: Int,
-                    height: Int,
-                    scalable: Bool,
-                    maintainAspectRatio: Bool) {
+        public init( internalID: UUID = UUID(),
+                     url: URL,
+                     clickthrough: URL?,
+                     pixels: AdPixels,
+                     id: String?,
+                     width: Int,
+                     height: Int,
+                     scalable: Bool,
+                     maintainAspectRatio: Bool) {
+            self.internalID = internalID
             self.url = url
             self.clickthrough = clickthrough
             self.pixels = pixels
@@ -34,17 +37,20 @@ public enum AdCreative: Hashable {
         }
     }
     public struct VPAID: Hashable {
+        public let internalID: UUID
         public let url: URL
         public let adParameters: String?
         public let clickthrough: URL?
         public let pixels: AdPixels
         public let id: String?
         
-        public init(url: URL,
+        public init(internalID: UUID = UUID(),
+                    url: URL,
                     adParameters: String?,
                     clickthrough: URL?,
                     pixels: AdPixels,
                     id: String?) {
+            self.internalID = internalID
             self.url = url
             self.adParameters = adParameters
             self.clickthrough = clickthrough


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Added `internal ID` too fix issue described in [PR](https://github.com/VerizonAdPlatforms/VerizonVideoPartnerSDK-iOS/pull/60)

<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](xxx)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


