### PR TITLE
Updated struct VRMFinalResult -> enum VRMFinalResult

### DIFF
--- a/PlayerCore/components/New VRM Core/VRMFinalResult.swift
+++ b/PlayerCore/components/New VRM Core/VRMFinalResult.swift
@@ -3,23 +3,38 @@
 
 import Foundation
 
-public struct VRMFinalResult {
-    static let initial = VRMFinalResult(result: nil)
+public enum VRMFinalResult: Equatable {
+    static let initial = VRMFinalResult.empty
     
-    public let result: VRMCore.Result?
+    case empty
+    case selected(result: VRMCore.Result)
+    case failed(result: VRMCore.Result)
+    
+    public var successResult: VRMCore.Result? {
+        guard case let .selected(result) = self else { return nil }
+        return result
+    }
+    
+    public var failedResult: VRMCore.Result? {
+        guard case let .failed(result) = self else { return nil }
+        return result
+    }
 }
 
 func reduce(state: VRMFinalResult, action: Action) -> VRMFinalResult {
     switch action {
     case let finalResult as VRMCore.SelectFinalResult:
-        return VRMFinalResult(result: VRMCore.Result(item: finalResult.item,
-                                                     inlineVAST: finalResult.inlineVAST))
+        return .selected( result: .init(item: finalResult.item,
+                                        inlineVAST: finalResult.inlineVAST))
     case is AdPlaybackFailed,
          is AdStartTimeout,
          is AdError,
-         is AdNotSupported,
-         is VRMCore.AdRequest:
-        return VRMFinalResult(result: nil)
+         is AdNotSupported:
+        guard let result = state.successResult else { return state }
+        return .failed(result: result)
+         
+    case is VRMCore.AdRequest:
+        return .empty
     default: return state
     }
 }

--- a/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
@@ -17,24 +17,37 @@ class VRMFinalResultComponentTest: XCTestCase {
                                      adParameters: nil,
                                      pixels: AdPixels(),
                                      id: nil)
-        let sut = reduce(state: VRMFinalResult.initial, action: VRMCore.selectFinalResult(item: vastItem,
-                                                                                          inlineVAST: vastModel))
-        XCTAssertEqual(sut.result?.inlineVAST, vastModel)
+        
+        let result = VRMCore.Result(item: vastItem, inlineVAST: vastModel)
+        let sut = reduce(state: VRMFinalResult.initial,
+                         action: VRMCore.selectFinalResult(item: vastItem,
+                                                           inlineVAST: vastModel))
+        XCTAssertEqual(sut.successResult?.inlineVAST, vastModel)
         
         var emptySut = reduce(state: sut, action: AdError(error: CustomError()))
-        XCTAssertNil(emptySut.result)
+        XCTAssertNil(emptySut.successResult)
+        XCTAssertNotNil(emptySut.failedResult)
+        XCTAssertEqual(emptySut, .failed(result: result))
         
         emptySut = reduce(state: sut, action: AdPlaybackFailed(error: CustomError() as NSError))
-        XCTAssertNil(emptySut.result)
+        XCTAssertNil(emptySut.successResult)
+        XCTAssertNotNil(emptySut.failedResult)
+        XCTAssertEqual(emptySut, .failed(result: result))
         
         emptySut = reduce(state: sut, action: AdStartTimeout())
-        XCTAssertNil(emptySut.result)
+        XCTAssertNil(emptySut.successResult)
+        XCTAssertNotNil(emptySut.failedResult)
+        XCTAssertEqual(emptySut, .failed(result: result))
         
         emptySut = reduce(state: sut, action: AdNotSupported())
-        XCTAssertNil(emptySut.result)
+        XCTAssertNil(emptySut.successResult)
+        XCTAssertNotNil(emptySut.failedResult)
+        XCTAssertEqual(emptySut, .failed(result: result))
         
         emptySut = reduce(state: sut, action: VRMCore.adRequest(url: URL(string:"url")!, id: UUID(), type: .midroll))
-        XCTAssertNil(emptySut.result)
+        XCTAssertNil(emptySut.successResult)
+        XCTAssertNil(emptySut.failedResult)
+        XCTAssertEqual(emptySut, .empty)
     }
 
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

Replace strcut with enum because it cause to error in `ad-issue`. We have to track ad issue, but in case of `AdError` action we get nil there.

<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](https://jira.ouroath.com/browse/OMSDK-2237)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

