### PR TITLE
Added progress pixel and refactored vast offset model

### DIFF
--- a/PlayerCore/components/AdPixels.swift
+++ b/PlayerCore/components/AdPixels.swift
@@ -25,6 +25,7 @@ public struct AdPixels: Hashable {
     public var close: URLs
     public var closeLinear: URLs
     public var collapse: URLs
+    public var progress: [Progress]
     
     public init(impression: URLs = [],
                 error: URLs = [],
@@ -44,7 +45,8 @@ public struct AdPixels: Hashable {
                 acceptInvitationLinear: URLs = [],
                 close: URLs = [],
                 closeLinear: URLs = [],
-                collapse: URLs = []) {
+                collapse: URLs = [],
+                progress: [Progress] = []) {
         self.impression = impression
         self.error = error
         self.clickTracking = clickTracking
@@ -64,5 +66,15 @@ public struct AdPixels: Hashable {
         self.close = close
         self.closeLinear = closeLinear
         self.collapse = collapse
+        self.progress = progress
+    }
+    public struct Progress: Hashable {
+        public let url: URL
+        public let offset: Ad.VASTModel.VASTOffset
+        
+        public init(url: URL, offset: Ad.VASTModel.VASTOffset) {
+            self.url = url
+            self.offset = offset
+        }
     }
 }

--- a/PlayerCore/components/AdVASTModel.swift
+++ b/PlayerCore/components/AdVASTModel.swift
@@ -7,7 +7,7 @@ extension Ad {
         public let adVerifications: [AdVerification]
         public let mp4MediaFiles: [MP4MediaFile]
         public let vpaidMediaFiles: [VPAIDMediaFile]
-        public let skipOffset: SkipOffset
+        public let skipOffset: VASTOffset
         public let clickthrough: URL?
         public let adParameters: String?
         public let pixels: AdPixels
@@ -46,7 +46,7 @@ extension Ad {
             }
         }
         
-        public enum SkipOffset: Hashable {
+        public enum VASTOffset: Hashable {
             case none
             case time(Int)
             case percentage(Int)
@@ -71,7 +71,7 @@ extension Ad {
         public init(adVerifications: [AdVerification],
                     mp4MediaFiles: [MP4MediaFile],
                     vpaidMediaFiles: [VPAIDMediaFile],
-                    skipOffset: SkipOffset,
+                    skipOffset: VASTOffset,
                     clickthrough: URL?,
                     adParameters: String?,
                     pixels: AdPixels,

--- a/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
+++ b/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
@@ -70,7 +70,8 @@ public extension AdPixels {
             acceptInvitationLinear: acceptInvitationLinear + pixels.acceptInvitationLinear,
             close: close + pixels.close,
             closeLinear: closeLinear + pixels.closeLinear,
-            collapse: collapse + pixels.collapse
+            collapse: collapse + pixels.collapse,
+            progress: progress + pixels.progress
         )
     }
 }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Added new pixel - `progress`;
- Replaced `SkipOffset` enum with `VastOffset` enum that now will not work only for skip.

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


