### PR TITLE
Added open measurement skip action and updated ad finish tracker

### DIFF
--- a/PlayerCore/OpenMeasurement_Tracking.swift
+++ b/PlayerCore/OpenMeasurement_Tracking.swift
@@ -22,6 +22,7 @@ extension OpenMeasurement {
         public let pause: () -> Void
         public let click: () -> Void
         public let volumeChange: (CGFloat) -> Void
+        public let skip: () -> Void
         
         public enum AdPosition {
             case preroll, midroll
@@ -37,7 +38,8 @@ extension OpenMeasurement {
                     resume: @escaping () -> Void,
                     pause: @escaping () -> Void,
                     click: @escaping () -> Void,
-                    volumeChange: @escaping (CGFloat) -> Void) {
+                    volumeChange: @escaping (CGFloat) -> Void,
+                    skip: @escaping () -> Void) {
             self.loaded = loaded
             self.bufferFinish = bufferFinish
             self.bufferStart = bufferStart
@@ -50,6 +52,7 @@ extension OpenMeasurement {
             self.pause = pause
             self.click = click
             self.volumeChange = volumeChange
+            self.skip = skip
         }
         
     }
@@ -70,5 +73,6 @@ extension OpenMeasurement.VideoEvents {
                                                    resume: {},
                                                    pause: {},
                                                    click: {},
-                                                   volumeChange: {_ in})
+                                                   volumeChange: {_ in},
+                                                   skip: {})
 }

--- a/PlayerCore/components/AdFinishTracker.swift
+++ b/PlayerCore/components/AdFinishTracker.swift
@@ -13,7 +13,7 @@ public enum AdFinishTracker {
 func reduce(state: AdFinishTracker, action: Action) -> AdFinishTracker {
     switch action {
     
-    case is ShowMP4Ad, is ShowVPAIDAd, is ShowAd:
+    case is AdRequest:
         return .unknown
     case is DropAd, is VRMCore.VRMResponseFetchFailed,
          is AdSkipped, is AdStopped,


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Added `skip` action for the open measurement.
- We now reset the `AdFinishTracker` by `AdRequest` action

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


