### PR TITLE
Added component for vrm processing time

### DIFF
--- a/PlayerCore.xcodeproj/project.pbxproj
+++ b/PlayerCore.xcodeproj/project.pbxproj
@@ -234,6 +234,8 @@
 		E2B0062421CD31A500B72485 /* VRMFetchItemQueueTestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2B0062321CD31A500B72485 /* VRMFetchItemQueueTestComponent.swift */; };
 		E2C1AEFA22099F8400812A5A /* VRMItemResponseTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C1AEF922099F8400812A5A /* VRMItemResponseTime.swift */; };
 		E2C1AF062209B37600812A5A /* VRMItemResponseTimeComponentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C1AF052209B37600812A5A /* VRMItemResponseTimeComponentTest.swift */; };
+		E2E5760B221B05650068C394 /* VRMProcessingTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E5760A221B05650068C394 /* VRMProcessingTime.swift */; };
+		E2E5760D221B0B190068C394 /* VRMProcessingTimeComponentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E5760C221B0B190068C394 /* VRMProcessingTimeComponentTest.swift */; };
 		E2FE095121FF62E5005E91C0 /* VRMFinalResultComponentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE095021FF62E5005E91C0 /* VRMFinalResultComponentTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -479,6 +481,8 @@
 		E2B0062321CD31A500B72485 /* VRMFetchItemQueueTestComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMFetchItemQueueTestComponent.swift; sourceTree = "<group>"; };
 		E2C1AEF922099F8400812A5A /* VRMItemResponseTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VRMItemResponseTime.swift; path = "components/New VRM Core/VRMItemResponseTime.swift"; sourceTree = "<group>"; };
 		E2C1AF052209B37600812A5A /* VRMItemResponseTimeComponentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMItemResponseTimeComponentTest.swift; sourceTree = "<group>"; };
+		E2E5760A221B05650068C394 /* VRMProcessingTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VRMProcessingTime.swift; path = "components/New VRM Core/VRMProcessingTime.swift"; sourceTree = "<group>"; };
+		E2E5760C221B0B190068C394 /* VRMProcessingTimeComponentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMProcessingTimeComponentTest.swift; sourceTree = "<group>"; };
 		E2FE095021FF62E5005E91C0 /* VRMFinalResultComponentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VRMFinalResultComponentTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -812,6 +816,7 @@
 				E23218DD2210BE12008DA177 /* VRMOtherError.swift */,
 				E287B08721F77C6200FC49AA /* VRMFinalResult.swift */,
 				E2C1AEF922099F8400812A5A /* VRMItemResponseTime.swift */,
+				E2E5760A221B05650068C394 /* VRMProcessingTime.swift */,
 			);
 			name = "New VRM Core";
 			sourceTree = "<group>";
@@ -860,6 +865,7 @@
 				E22B6AD121EF6E9000D480A0 /* VRMProcessingResultComponentTests.swift */,
 				E2FE095021FF62E5005E91C0 /* VRMFinalResultComponentTest.swift */,
 				E2C1AF052209B37600812A5A /* VRMItemResponseTimeComponentTest.swift */,
+				E2E5760C221B0B190068C394 /* VRMProcessingTimeComponentTest.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1136,6 +1142,7 @@
 				06EC86B32213334B00CB4A8E /* SkipAdAction.swift in Sources */,
 				06CD5378213D909C00C5B783 /* AdClickthrough.swift in Sources */,
 				06CD532C213D908500C5B783 /* ContentFullScreenToggle.swift in Sources */,
+				E2E5760B221B05650068C394 /* VRMProcessingTime.swift in Sources */,
 				06CD5420213D988400C5B783 /* Pause.swift in Sources */,
 				06CD52CE213D905F00C5B783 /* AdClickThroughAction.swift in Sources */,
 				06CD5375213D909C00C5B783 /* LoadedTimeRanges.swift in Sources */,
@@ -1190,6 +1197,7 @@
 				06CD53E6213D917800C5B783 /* AdKillTest.swift in Sources */,
 				E2FE095121FF62E5005E91C0 /* VRMFinalResultComponentTest.swift in Sources */,
 				E2C1AF062209B37600812A5A /* VRMItemResponseTimeComponentTest.swift in Sources */,
+				E2E5760D221B0B190068C394 /* VRMProcessingTimeComponentTest.swift in Sources */,
 				06BA6B602159201700948001 /* OpenMeasurementActionCreatorTestCase.swift in Sources */,
 				06CD5401213D917800C5B783 /* SeekingActionCreatorTestCase.swift in Sources */,
 				06CD53F3213D917800C5B783 /* MuteActionCreatorTestCase.swift in Sources */,

--- a/PlayerCore/components/New VRM Core/VRMProcessingTime.swift
+++ b/PlayerCore/components/New VRM Core/VRMProcessingTime.swift
@@ -1,0 +1,28 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import Foundation
+
+public enum VRMProcessingTime {
+    static let initial = VRMProcessingTime.empty
+    
+    case inProgress(startAt: Date)
+    case finished(startAt: Date, finishAt: Date)
+    case empty
+}
+
+func reduce(state: VRMProcessingTime, action: Action) -> VRMProcessingTime {
+    switch action {
+    case is VRMCore.AdRequest, is AdRequest:
+        return .inProgress(startAt: Date())
+        
+    case is ShowMP4Ad, is ShowVPAIDAd, is ShowAd:
+        guard case let .inProgress(stateAt) = state else { return state }
+        return .finished(startAt: stateAt, finishAt: Date())
+        
+    case is VRMCore.NoGroupsToProcess, is VRMCore.VRMResponseFetchFailed:
+        return .empty
+        
+    default: return state
+    }
+}

--- a/PlayerCore/components/State.swift
+++ b/PlayerCore/components/State.swift
@@ -53,6 +53,7 @@ public struct State {
     public let vrmOtherError: VRMOtherError
     public let vrmFinalResult: VRMFinalResult
     public let vrmItemResponseTime: VRMItemResponseTime
+    public let vrmProcessingTime: VRMProcessingTime
 }
 
 
@@ -143,7 +144,8 @@ extension State {
             vrmRedirectError: VRMRedirectError(erroredItems: []),
             vrmOtherError: VRMOtherError(erroredItems: []),
             vrmFinalResult: .initial,
-            vrmItemResponseTime: .initial
+            vrmItemResponseTime: .initial,
+            vrmProcessingTime: .initial
         )
     }
 }
@@ -201,6 +203,7 @@ public func reduce(state: State, action: Action) -> State {
         vrmRedirectError: reduce(state: state.vrmRedirectError, action: action),
         vrmOtherError: reduce(state: state.vrmOtherError, action: action),
         vrmFinalResult: reduce(state: state.vrmFinalResult, action: action),
-        vrmItemResponseTime: reduce(state: state.vrmItemResponseTime, action: action)
+        vrmItemResponseTime: reduce(state: state.vrmItemResponseTime, action: action),
+        vrmProcessingTime: reduce(state: state.vrmProcessingTime, action: action)
     )
 }

--- a/PlayerCoreTests/Components/VRMProcessingTimeComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMProcessingTimeComponentTest.swift
@@ -1,0 +1,71 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import XCTest
+@testable import PlayerCore
+
+class VRMProcessingTimeComponentTest: XCTestCase {
+    
+    let url = URL(string: "http://test.com")!
+    
+    func testStartProcessingOldCore() {
+        let initial = VRMProcessingTime.initial
+        
+        let sut = reduce(state: initial, action: adRequest(url: url, id: UUID(), type: .preroll))
+        guard case .inProgress = sut else { XCTFail("on adRequest sut should be .inProgress, actual \(sut)"); return }
+    }
+    
+    func testStartProcessingNewCore() {
+        let initial = VRMProcessingTime.initial
+        
+        let sut = reduce(state: initial, action: VRMCore.adRequest(url: url, id: UUID(), type: .preroll))
+        guard case .inProgress = sut else { XCTFail("on VRMCore.adRequest sut should be .inProgress, actual \(sut)"); return }
+    }
+    
+    func testFinishMP4Processing() {
+        let initialDate = Date()
+        let mp4 = AdCreative.MP4(internalID: UUID(),
+                                 url: url,
+                                 clickthrough: url,
+                                 pixels: AdPixels(),
+                                 id: "",
+                                 width: 30,
+                                 height: 30,
+                                 scalable: false,
+                                 maintainAspectRatio: true)
+        let initial = VRMProcessingTime.inProgress(startAt: initialDate)
+        
+        let sut = reduce(state: initial, action: showMP4Ad(creative: mp4, id: UUID()))
+        guard case let .finished(startAt, _) = sut else { XCTFail("on showMP4Ad sut should be .finished, actual \(sut)"); return }
+        XCTAssertEqual(initialDate, startAt)
+    }
+    
+    func testFinishVPAIDProcessing() {
+        let initialDate = Date()
+        let vpaid = AdCreative.VPAID(internalID: UUID(),
+                                   url: url,
+                                   adParameters: nil,
+                                   clickthrough: nil,
+                                   pixels: .init(),
+                                   id: nil)
+        let initial = VRMProcessingTime.inProgress(startAt: initialDate)
+        
+        let sut = reduce(state: initial, action: showVPAIDAd(creative: vpaid, id: UUID()))
+        guard case let .finished(startAt, _) = sut else { XCTFail("on showVPAIDAd sut should be .finished, actual \(sut)"); return }
+        XCTAssertEqual(initialDate, startAt)
+    }
+    
+    func testFailedProcessing() {
+        let initial = VRMProcessingTime.inProgress(startAt: Date())
+        
+        let sut = reduce(state: initial, action: VRMCore.noGroupsToProcess(id: UUID()))
+        guard case .empty = sut else { XCTFail("on noGroupsToProcess sut should be .empty, actual \(sut)"); return }
+    }
+    
+    func testFailedToGetVRMResponse() {
+        let initial = VRMProcessingTime.inProgress(startAt: Date())
+        
+        let sut = reduce(state: initial, action: VRMCore.adResponseFetchFailed(requestID: UUID()))
+        guard case .empty = sut else { XCTFail("on adResponseFetchFailed sut should be .empty, actual \(sut)"); return }
+    }
+}


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

This component will be used for `VRM_PROCESSING` telemetry.
It displays time from `VRMRequest` to getting playable ad.

<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](https://jira.ouroath.com/browse/OMSDK-2269)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

