### PR TITLE
Moved ad progress from pixels and added component for it

### DIFF
--- a/PlayerCore.xcodeproj/project.pbxproj
+++ b/PlayerCore.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		063C8342221C32A90052C1DC /* AdProgressComponentTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063C8341221C32A90052C1DC /* AdProgressComponentTestCase.swift */; };
+		063C8344221C32EE0052C1DC /* AdVASTProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063C8343221C32EE0052C1DC /* AdVASTProgress.swift */; };
 		0641A40921663EB6004E7A0F /* PlaybackBuffering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0641A40821663EB6004E7A0F /* PlaybackBuffering.swift */; };
 		0641A40B21663F1E004E7A0F /* PlaybackBufferingAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0641A40A21663F1E004E7A0F /* PlaybackBufferingAction.swift */; };
 		0641A40D216640FC004E7A0F /* UpdatePlaybackBuffering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0641A40C216640FC004E7A0F /* UpdatePlaybackBuffering.swift */; };
@@ -250,6 +252,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		063C8341221C32A90052C1DC /* AdProgressComponentTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdProgressComponentTestCase.swift; sourceTree = "<group>"; };
+		063C8343221C32EE0052C1DC /* AdVASTProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AdVASTProgress.swift; path = components/AdVASTProgress.swift; sourceTree = "<group>"; };
 		0641A40821663EB6004E7A0F /* PlaybackBuffering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBuffering.swift; sourceTree = "<group>"; };
 		0641A40A21663F1E004E7A0F /* PlaybackBufferingAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBufferingAction.swift; sourceTree = "<group>"; };
 		0641A40C216640FC004E7A0F /* UpdatePlaybackBuffering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePlaybackBuffering.swift; sourceTree = "<group>"; };
@@ -671,6 +675,7 @@
 				06CD5357213D909800C5B783 /* AdInfoHolder.swift */,
 				06CD5354213D909800C5B783 /* AdKill.swift */,
 				06CD5369213D909900C5B783 /* AdPixels.swift */,
+				063C8343221C32EE0052C1DC /* AdVASTProgress.swift */,
 				06CD5352213D909800C5B783 /* AdVASTModel.swift */,
 				06CD535D213D909800C5B783 /* AdVRMManager.swift */,
 				06CD536D213D909B00C5B783 /* AdVRMManager_Hashable.swift */,
@@ -824,48 +829,49 @@
 		E24103B221BEE1ED00036290 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				06CD53B6213D916E00C5B783 /* AdClickthroughComponentTestCase.swift */,
+				06CD53CE213D917500C5B783 /* AdComponentTestCase.swift */,
+				0693BA7C21FF34B9004C09CB /* AdCreativeComponentTestCase.swift */,
+				06CD53BD213D916F00C5B783 /* AdFinishTrackerComponentTestCase.swift */,
+				06CD53B5213D916E00C5B783 /* AdKillTest.swift */,
+				063C8341221C32A90052C1DC /* AdProgressComponentTestCase.swift */,
 				06CD53C1213D917000C5B783 /* AdVRMManagerComponentTestCase.swift */,
 				06CD53CA213D917400C5B783 /* AirPlayComponentTestCase.swift */,
 				06CD53B0213D916D00C5B783 /* AverageBitrateComponentTestCase.swift */,
 				06CD53BC213D916F00C5B783 /* CurrentTimeComponentTestCase.swift */,
 				06CD53D1213D917500C5B783 /* DurationComponentTestCase.swift */,
-				06CD53B5213D916E00C5B783 /* AdKillTest.swift */,
-				06CD53B6213D916E00C5B783 /* AdClickthroughComponentTestCase.swift */,
-				06CD53CE213D917500C5B783 /* AdComponentTestCase.swift */,
-				06CD53BD213D916F00C5B783 /* AdFinishTrackerComponentTestCase.swift */,
 				06CD53BF213D917000C5B783 /* InteractiveSeekingTestCaseComponent.swift */,
 				06CD53C9213D917400C5B783 /* LoadedTimeRangesComponentTestCase.swift */,
 				06CD53CF213D917500C5B783 /* MediaOptionsComponentTestCase.swift */,
 				06CD53D6213D917600C5B783 /* MuteComponentTestCase.swift */,
-				06BA6B612159244700948001 /* OpenMeasurementComponentTestCase.swift */,
 				06BA6BDA215B96E400948001 /* OMServiceScriptComponentTestCase.swift */,
+				06BA6B612159244700948001 /* OpenMeasurementComponentTestCase.swift */,
 				06CD53B4213D916E00C5B783 /* PictureInPictureComponentTestCase.swift */,
+				0641A4132166524F004E7A0F /* PlaybackBufferingComponentTestCase.swift */,
 				06CD53CC213D917500C5B783 /* PlaybackDurationComponentTestCase.swift */,
 				06CD53AD213D916D00C5B783 /* PlaybackSessionComponentTestCase.swift */,
 				06CD53BB213D916F00C5B783 /* PlaybackStatusComponentTestCase.swift */,
-				0641A4132166524F004E7A0F /* PlaybackBufferingComponentTestCase.swift */,
 				06CD53AC213D916D00C5B783 /* PlayerSessionComponentTestCase.swift */,
 				06CD53B8213D916E00C5B783 /* PlaylistComponentTestCase.swift */,
 				06CD53B2213D916D00C5B783 /* RateComponentTestCase.swift */,
-				0693BA7C21FF34B9004C09CB /* AdCreativeComponentTestCase.swift */,
+				E257A9F221C910750016D35A /* ScheduledVRMItemsComponentTest.swift */,
 				06CD53C3213D917100C5B783 /* TimerComponentTest.swift */,
 				06CD53AE213D916D00C5B783 /* ViewportComponentTestCase.swift */,
 				06CD53DB213D917800C5B783 /* VPAIDActionCreatorTestCase.swift */,
 				06CD53AB213D916C00C5B783 /* VPAIDErrorsReducerTestCase.swift */,
 				06CD53C8213D917400C5B783 /* VPAIDStateComponentTestCase.swift */,
-				E24103B321BEE4E000036290 /* VRMRequestStatusComponentTest.swift */,
-				E24103DC21C0442100036290 /* VRMResponseComponentTest.swift */,
 				E257A9C021C7BB670016D35A /* VRMCurrentGroupComponentTest.swift */,
-				E257A9C221C7BD6A0016D35A /* VRMGroupsQueueComponentTest.swift */,
-				E257A9C621C7D2930016D35A /* VRMTopPriorityItemComponentTest.swift */,
-				E257A9F221C910750016D35A /* ScheduledVRMItemsComponentTest.swift */,
 				E2B0062321CD31A500B72485 /* VRMFetchItemQueueTestComponent.swift */,
+				E2FE095021FF62E5005E91C0 /* VRMFinalResultComponentTest.swift */,
+				E257A9C221C7BD6A0016D35A /* VRMGroupsQueueComponentTest.swift */,
+				E2C1AF052209B37600812A5A /* VRMItemResponseTimeComponentTest.swift */,
 				E22B6A8221D1490B00D480A0 /* VRMParseItemQueueComponentTest.swift */,
 				E22B6ABB21D52A3E00D480A0 /* VRMParsingResultComponentTest.swift */,
 				E22B6AD121EF6E9000D480A0 /* VRMProcessingResultComponentTests.swift */,
-				E2FE095021FF62E5005E91C0 /* VRMFinalResultComponentTest.swift */,
-				E2C1AF052209B37600812A5A /* VRMItemResponseTimeComponentTest.swift */,
 				E2E5760C221B0B190068C394 /* VRMProcessingTimeComponentTest.swift */,
+				E24103B321BEE4E000036290 /* VRMRequestStatusComponentTest.swift */,
+				E24103DC21C0442100036290 /* VRMResponseComponentTest.swift */,
+				E257A9C621C7D2930016D35A /* VRMTopPriorityItemComponentTest.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1064,6 +1070,7 @@
 				06CD5394213D90AF00C5B783 /* PlaybackModel.swift in Sources */,
 				E2C1AEFA22099F8400812A5A /* VRMItemResponseTime.swift in Sources */,
 				06CD538F213D909C00C5B783 /* AdVRMManager_Hashable.swift in Sources */,
+				063C8344221C32EE0052C1DC /* AdVASTProgress.swift in Sources */,
 				06CD5337213D908500C5B783 /* AdStartTimeoutActionCreator.swift in Sources */,
 				064FA41F2153C5DA005D990A /* OpenMeasurement.swift in Sources */,
 				E22B6B0E21F5E6A800D480A0 /* VRMFetchingError.swift in Sources */,
@@ -1173,6 +1180,7 @@
 				06CD53F2213D917800C5B783 /* AdVRMManagerComponentTestCase.swift in Sources */,
 				E22B6A8321D1490B00D480A0 /* VRMParseItemQueueComponentTest.swift in Sources */,
 				06CD53E3213D917800C5B783 /* RateComponentTestCase.swift in Sources */,
+				063C8342221C32A90052C1DC /* AdProgressComponentTestCase.swift in Sources */,
 				06CD53E7213D917800C5B783 /* AdClickthroughComponentTestCase.swift in Sources */,
 				06CD5404213D917800C5B783 /* PlayActionCreatorTestCase.swift in Sources */,
 				06CD53E8213D917800C5B783 /* UpdateExternalPlaybackActionCreatorTestCase.swift in Sources */,

--- a/PlayerCore/action creators/UpdateDuration.swift
+++ b/PlayerCore/action creators/UpdateDuration.swift
@@ -6,6 +6,6 @@ public func updateContentDuration(duration: CMTime) -> Action {
     return UpdateContentDuration(newDuration: duration)
 }
 
-public func updateAdDuration(duration: CMTime) -> Action {
-    return UpdateAdDuration(newDuration: duration)
+public func updateAdDuration(duration: CMTime, vastAdProgress: [Ad.VASTModel.AdProgress]) -> Action {
+    return UpdateAdDuration(newDuration: duration, vastAdProgress: vastAdProgress)
 }

--- a/PlayerCore/actions/UpdateDurationAction.swift
+++ b/PlayerCore/actions/UpdateDurationAction.swift
@@ -8,4 +8,5 @@ struct UpdateContentDuration: Action {
 
 struct UpdateAdDuration: Action {
     let newDuration: CMTime?
+    let vastAdProgress: [Ad.VASTModel.AdProgress]
 }

--- a/PlayerCore/components/AdPixels.swift
+++ b/PlayerCore/components/AdPixels.swift
@@ -25,7 +25,6 @@ public struct AdPixels: Hashable {
     public var close: URLs
     public var closeLinear: URLs
     public var collapse: URLs
-    public var progress: [Progress]
     
     public init(impression: URLs = [],
                 error: URLs = [],
@@ -45,8 +44,7 @@ public struct AdPixels: Hashable {
                 acceptInvitationLinear: URLs = [],
                 close: URLs = [],
                 closeLinear: URLs = [],
-                collapse: URLs = [],
-                progress: [Progress] = []) {
+                collapse: URLs = []) {
         self.impression = impression
         self.error = error
         self.clickTracking = clickTracking
@@ -66,15 +64,5 @@ public struct AdPixels: Hashable {
         self.close = close
         self.closeLinear = closeLinear
         self.collapse = collapse
-        self.progress = progress
-    }
-    public struct Progress: Hashable {
-        public let url: URL
-        public let offset: Ad.VASTModel.VASTOffset
-        
-        public init(url: URL, offset: Ad.VASTModel.VASTOffset) {
-            self.url = url
-            self.offset = offset
-        }
     }
 }

--- a/PlayerCore/components/AdVASTModel.swift
+++ b/PlayerCore/components/AdVASTModel.swift
@@ -7,9 +7,10 @@ extension Ad {
         public let adVerifications: [AdVerification]
         public let mp4MediaFiles: [MP4MediaFile]
         public let vpaidMediaFiles: [VPAIDMediaFile]
-        public let skipOffset: VASTOffset
+        public let skipOffset: VASTOffset?
         public let clickthrough: URL?
         public let adParameters: String?
+        public let adProgress: [AdProgress]
         public let pixels: AdPixels
         public let id: String?
         
@@ -47,9 +48,18 @@ extension Ad {
         }
         
         public enum VASTOffset: Hashable {
-            case none
             case time(Int)
             case percentage(Int)
+        }
+        
+        public struct AdProgress: Hashable {
+            public let url: URL
+            public let offset: Ad.VASTModel.VASTOffset
+            
+            public init(url: URL, offset: Ad.VASTModel.VASTOffset) {
+                self.url = url
+                self.offset = offset
+            }
         }
         
         public struct AdVerification: Hashable {
@@ -71,9 +81,10 @@ extension Ad {
         public init(adVerifications: [AdVerification],
                     mp4MediaFiles: [MP4MediaFile],
                     vpaidMediaFiles: [VPAIDMediaFile],
-                    skipOffset: VASTOffset,
+                    skipOffset: VASTOffset?,
                     clickthrough: URL?,
                     adParameters: String?,
+                    adProgress: [AdProgress],
                     pixels: AdPixels,
                     id: String?) {
             self.adVerifications = adVerifications
@@ -82,6 +93,7 @@ extension Ad {
             self.skipOffset = skipOffset
             self.clickthrough = clickthrough
             self.adParameters = adParameters
+            self.adProgress = adProgress
             self.pixels = pixels
             self.id = id
         }

--- a/PlayerCore/components/AdVASTProgress.swift
+++ b/PlayerCore/components/AdVASTProgress.swift
@@ -1,0 +1,32 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+public struct AdVASTProgress {
+    public let pixels: [Pixel]
+    
+    public struct Pixel {
+        public let url: URL
+        public let offsetInSeconds: Int
+    }
+}
+
+func reduce(state: AdVASTProgress, action: Action) -> AdVASTProgress {
+    switch action {
+    case is AdRequest:
+        return AdVASTProgress(pixels: [])
+    case let action as UpdateAdDuration:
+        guard let duration = action.newDuration else { return state }
+        return AdVASTProgress(pixels: action.vastAdProgress.compactMap {
+            var offsetInSeconds: Int?
+            switch $0.offset {
+            case .time(let offset):
+                offsetInSeconds = offset
+            case .percentage(let percent):
+                offsetInSeconds = Int(duration.seconds.rounded() / 100 * Double(percent))
+            }
+            guard let offset = offsetInSeconds else { return nil }
+            return AdVASTProgress.Pixel(url: $0.url, offsetInSeconds: offset)
+        })
+    default: return state
+    }
+}

--- a/PlayerCore/components/State.swift
+++ b/PlayerCore/components/State.swift
@@ -8,6 +8,7 @@ public struct State {
     public let ad: Ad
     public let adKill: AdKill
     public let adMaxShowTime: TimerSession
+    public let adProgress: AdVASTProgress
     public let selectedAdCreative: AdCreative
     public let openMeasurement: OpenMeasurement
     public let serviceScript: OpenMeasurementServiceScript
@@ -88,6 +89,7 @@ extension State {
             adMaxShowTime: .init(state: .stopped,
                                  startAdSession: nil,
                                  allowedDuration: Double(maxAdDuration)),
+            adProgress: .init(pixels: []),
             selectedAdCreative: .none,
             openMeasurement: isOpenMeasurementEnabled ? .inactive : .disabled,
             serviceScript: OpenMeasurementServiceScript.none,
@@ -159,6 +161,7 @@ public func reduce(state: State, action: Action) -> State {
         ad: reduce(state: state.ad, action: action),
         adKill: reduce(state: state.adKill, action: action),
         adMaxShowTime: reduce(state: state.adMaxShowTime, action: action),
+        adProgress: reduce(state: state.adProgress, action: action),
         selectedAdCreative: reduce(state: state.selectedAdCreative, action: action),
         openMeasurement: reduce(state: state.openMeasurement, action: action),
         serviceScript: reduce(state: state.serviceScript, action: action),

--- a/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
+++ b/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
@@ -44,6 +44,7 @@ public extension Ad.VASTModel {
             skipOffset: skipOffset,
             clickthrough: clickthrough,
             adParameters: adParameters,
+            adProgress: self.adProgress + adProgress,
             pixels: self.pixels.merge(with: pixels),
             id: id)
     }
@@ -70,8 +71,7 @@ public extension AdPixels {
             acceptInvitationLinear: acceptInvitationLinear + pixels.acceptInvitationLinear,
             close: close + pixels.close,
             closeLinear: closeLinear + pixels.closeLinear,
-            collapse: collapse + pixels.collapse,
-            progress: progress + pixels.progress
+            collapse: collapse + pixels.collapse
         )
     }
 }

--- a/PlayerCoreTests/Components/AdProgressComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdProgressComponentTestCase.swift
@@ -1,0 +1,30 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import XCTest
+@testable import PlayerCore
+
+class AdProgressComponentTestCase: XCTestCase {
+    let initial = AdVASTProgress(pixels: [])
+    
+    let timeProgress = Ad.VASTModel.AdProgress(url: testUrl, offset: Ad.VASTModel.VASTOffset.time(15))
+    let percentageProgress = Ad.VASTModel.AdProgress(url: testUrl, offset: Ad.VASTModel.VASTOffset.percentage(50))
+    
+    func testReducer() {
+        var sut = reduce(state: initial, action: UpdateAdDuration(newDuration: nil, vastAdProgress: [timeProgress]))
+        XCTAssertTrue(sut.pixels.isEmpty)
+        
+        sut = reduce(state: sut, action: UpdateAdDuration(newDuration: toCMTime(60), vastAdProgress: []))
+        XCTAssertTrue(sut.pixels.isEmpty)
+        
+        sut = reduce(state: sut, action: UpdateAdDuration(newDuration: toCMTime(60), vastAdProgress: [timeProgress]))
+        XCTAssertEqual(sut.pixels.first?.offsetInSeconds, 15)
+        
+        sut = reduce(state: sut, action: UpdateAdDuration(newDuration: toCMTime(60), vastAdProgress: [percentageProgress]))
+        XCTAssertEqual(sut.pixels.first?.offsetInSeconds, 30)
+        
+        sut = reduce(state: sut, action: AdRequest(url: testUrl, id: UUID(), type: .midroll))
+        XCTAssertTrue(sut.pixels.isEmpty)
+    }
+}
+

--- a/PlayerCoreTests/Components/DurationComponentTestCase.swift
+++ b/PlayerCoreTests/Components/DurationComponentTestCase.swift
@@ -14,7 +14,7 @@ class DurationComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.ad, nil)
         XCTAssertEqual(sut.content, nil)
         
-        sut = reduce(state: sut, action: UpdateAdDuration(newDuration: CMTime.zero))
+        sut = reduce(state: sut, action: UpdateAdDuration(newDuration: CMTime.zero, vastAdProgress: []))
         XCTAssertEqual(sut.ad, CMTime.zero)
         XCTAssertEqual(sut.content, nil)
         

--- a/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
@@ -16,6 +16,7 @@ class VRMFinalResultComponentTest: XCTestCase {
                                      skipOffset: .none,
                                      clickthrough: nil,
                                      adParameters: nil,
+                                     adProgress: [],
                                      pixels: AdPixels(),
                                      id: nil)
         

--- a/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
@@ -41,6 +41,7 @@ class VRMParsingResultComponentTest: XCTestCase {
                                   skipOffset: .none,
                                   clickthrough: nil,
                                   adParameters: nil,
+                                  adProgress: [],
                                   pixels: AdPixels(),
                                   id: "")
         
@@ -95,6 +96,7 @@ class VRMParsingResultComponentTest: XCTestCase {
                                   skipOffset: .none,
                                   clickthrough: nil,
                                   adParameters: nil,
+                                  adProgress: [],
                                   pixels: AdPixels(impression: [impression3]),
                                   id: "")
         sut = reduce(state: sut, action: VRMCore.completeItemParsing(originalItem: urlItem,

--- a/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
+++ b/PlayerCoreTests/Components/VRMProcessingResultComponentTests.swift
@@ -12,6 +12,7 @@ class VRMProcessingResultComponentTests: XCTestCase {
                                   skipOffset: .none, 
                                   clickthrough: nil,
                                   adParameters: nil,
+                                  adProgress: [],
                                   pixels: AdPixels(),
                                   id: nil)
     

--- a/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
+++ b/PlayerCoreTests/PlayAdActionCreatorTestCase.swift
@@ -65,6 +65,7 @@ extension Ad.VASTModel {
             skipOffset: .none,
             clickthrough: nil,
             adParameters: nil,
+            adProgress: [],
             pixels: AdPixels(impression: [],
                              error: [],
                              clickTracking: [],

--- a/PlayerCoreTests/utils/VRMMockGenerator.swift
+++ b/PlayerCoreTests/utils/VRMMockGenerator.swift
@@ -33,6 +33,7 @@ enum VRMMockGenerator {
                             skipOffset: .none,
                             clickthrough: nil,
                             adParameters: nil,
+                            adProgress: [],
                             pixels: .init(),
                             id: nil)
     }


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Moved `adProgress` from `AdPixels` to `VASTModel`;
- `UpdateAdDuration` action now will get progress from vast model.
- `AdProgress` component will handle `UpdateAdDuration` action and will count offset in seconds if it will come in percentage.

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


