### PR TITLE
Reset AdFinishTracker on New VRM Core Request

### DIFF
--- a/PlayerCore/components/AdFinishTracker.swift
+++ b/PlayerCore/components/AdFinishTracker.swift
@@ -13,7 +13,7 @@ public enum AdFinishTracker {
 func reduce(state: AdFinishTracker, action: Action) -> AdFinishTracker {
     switch action {
     
-    case is AdRequest:
+    case is AdRequest, is VRMCore.AdRequest:
         return .unknown
     case is DropAd, is VRMCore.VRMResponseFetchFailed,
          is AdSkipped, is AdStopped,

--- a/PlayerCoreTests/Components/AdFinishTrackerComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdFinishTrackerComponentTestCase.swift
@@ -5,6 +5,22 @@ import XCTest
 @testable import PlayerCore
 
 class AdFinishTrackerComponentTestCase: XCTestCase {
+    
+    func testOnAdRequest() {
+        let url = URL(string: "http://test.com")!
+        let initial = AdFinishTracker.successfullyCompleted
+        
+        var sut = reduce(state: initial,
+                         action: AdRequest(url: url, id: UUID(), type: .preroll))
+        
+        XCTAssertEqual(sut, .unknown)
+        
+        sut = reduce(state: initial,
+                     action: VRMCore.AdRequest(url: url, id: UUID(), type: .preroll))
+        
+        XCTAssertEqual(sut, .unknown)
+    }
+    
     func testReduceOnShowAd() {
         let initial = AdFinishTracker.unknown
         let sut = reduce(state: initial,


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes

### Issue
In case of array of videos or replay we don't fir vast tracers and start/finish pixels.
___

### Fix
Reset `AdFinishTracker` to `.unknown` case on AdRequest from new vrm core.

<!-- Remove this if there is no ticket for this PR. -->
[JIRA Ticket](https://jira.ouroath.com/browse/OMSDK-2278)

@VerizonAdPlatforms/mobile-sdk-developers: Please review.

