### PR TITLE
Added ad progress in wrapper vast model

### DIFF
--- a/PlayerCore/components/New VRM Core/VRMParsingResult.swift
+++ b/PlayerCore/components/New VRM Core/VRMParsingResult.swift
@@ -23,13 +23,15 @@ func reduce(state: VRMParsingResult, action: Action) -> VRMParsingResult {
         if let currentVASTModel = newState.parsedVASTs[finishParsing.originalItem]?.vastModel {
             switch(currentVASTModel, finishParsing.vastModel) {
             case let (.wrapper(currentWrapper), .wrapper(processedWrapper)):
-                let mergedWrapper = processedWrapper.merge(with: currentWrapper.pixels,
-                                                           and: currentWrapper.adVerifications)
+                let mergedWrapper = processedWrapper.merge(pixels: currentWrapper.pixels,
+                                                           verifications: currentWrapper.adVerifications,
+                                                           adProgress: currentWrapper.adProgress)
                 newState.parsedVASTs[finishParsing.originalItem] = .init(vastModel: .wrapper(mergedWrapper))
                 return newState
             case let (.wrapper(currentWrapper), .inline(resultModel)):
-                let mergedResult = resultModel.merge(with: currentWrapper.pixels,
-                                                     and: currentWrapper.adVerifications)
+                let mergedResult = resultModel.merge(pixels: currentWrapper.pixels,
+                                                     verifications: currentWrapper.adVerifications,
+                                                     adProgress: currentWrapper.adProgress)
                 newState.parsedVASTs[finishParsing.originalItem] = .init(vastModel: .inline(mergedResult))
             case (.inline, _):
                 fatalError("Tried to complete already completed item")

--- a/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
+++ b/PlayerCore/player model/VRM/VRMCoreVASTModel.swift
@@ -12,13 +12,16 @@ public extension VRMCore {
             public let tagURL: URL
             public let adVerifications: [Ad.VASTModel.AdVerification]
             public let pixels: AdPixels
+            public let adProgress: [Ad.VASTModel.AdProgress]
             
             public init(tagURL: URL,
                         adVerifications: [Ad.VASTModel.AdVerification],
-                        pixels: AdPixels) {
+                        pixels: AdPixels,
+                        adProgress: [Ad.VASTModel.AdProgress]) {
                 self.tagURL = tagURL
                 self.adVerifications = adVerifications
                 self.pixels = pixels
+                self.adProgress = adProgress
             }
         }
         
@@ -28,15 +31,20 @@ public extension VRMCore {
 }
 
 public extension VRMCore.VASTModel.WrapperModel {
-    func merge(with pixels: AdPixels, and verifications: [Ad.VASTModel.AdVerification]) -> VRMCore.VASTModel.WrapperModel {
+    func merge(pixels: AdPixels,
+               verifications: [Ad.VASTModel.AdVerification],
+               adProgress: [Ad.VASTModel.AdProgress]) -> VRMCore.VASTModel.WrapperModel {
         return VRMCore.VASTModel.WrapperModel(tagURL: tagURL,
                                               adVerifications: self.adVerifications + verifications,
-                                              pixels: self.pixels.merge(with: pixels))
+                                              pixels: self.pixels.merge(with: pixels),
+                                              adProgress: self.adProgress + adProgress)
     }
 }
 
 public extension Ad.VASTModel {
-    public func merge(with pixels: AdPixels, and verifications: [Ad.VASTModel.AdVerification]) -> Ad.VASTModel {
+    public func merge(pixels: AdPixels,
+                      verifications: [Ad.VASTModel.AdVerification],
+                      adProgress: [Ad.VASTModel.AdProgress]) -> Ad.VASTModel {
         return PlayerCore.Ad.VASTModel(
             adVerifications: self.adVerifications + verifications,
             mp4MediaFiles: mp4MediaFiles,

--- a/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMParsingResultComponentTest.swift
@@ -11,6 +11,7 @@ class VRMParsingResultComponentTest: XCTestCase {
     
     let tag1URL = URL(string: "http://tag1.com")!
     let impression1 = URL(string:"http://impression1.com")!
+    let adProgress1 = Ad.VASTModel.AdProgress(url: URL(string: "http://test1")!, offset: .time(5))
     let adVerification1 = Ad.VASTModel.AdVerification(vendorKey: "vendorKey",
                                                       javaScriptResource: URL(string:"http://javaScriptResource1.com")!,
                                                       verificationParameters: nil,
@@ -18,12 +19,14 @@ class VRMParsingResultComponentTest: XCTestCase {
     
     let tag2URL = URL(string: "http://tag2.com")!
     let impression2 = URL(string:"http://impression2.com")!
+    let adProgress2 = Ad.VASTModel.AdProgress(url: URL(string: "http://test2")!, offset: .time(10))
     let adVerification2 = Ad.VASTModel.AdVerification(vendorKey: "vendorKey",
                                                       javaScriptResource: URL(string:"http://javaScriptResource2.com")!,
                                                       verificationParameters: nil,
                                                       verificationNotExecuted: nil)
     
     let impression3 = URL(string:"http://impression3.com")!
+    let adProgress3 = Ad.VASTModel.AdProgress(url: URL(string: "http://test3")!, offset: .percentage(32))
     let adVerification3 = Ad.VASTModel.AdVerification(vendorKey: "vendorKey",
                                                       javaScriptResource: URL(string:"http://javaScriptResource3.com")!,
                                                       verificationParameters: nil,
@@ -33,7 +36,8 @@ class VRMParsingResultComponentTest: XCTestCase {
         var sut = VRMParsingResult.initial
         let wrapper = VRMCore.VASTModel.WrapperModel(tagURL: tag1URL,
                                                      adVerifications: [adVerification1],
-                                                     pixels: AdPixels(impression: [impression1]))
+                                                     pixels: AdPixels(impression: [impression1]),
+                                                     adProgress: [adProgress1])
         
         let adVAST = Ad.VASTModel(adVerifications: [],
                                   mp4MediaFiles: [],
@@ -59,13 +63,15 @@ class VRMParsingResultComponentTest: XCTestCase {
     func testSecondWrapperForSameItem() {
         let wrapper = VRMCore.VASTModel.WrapperModel(tagURL: tag1URL,
                                                      adVerifications: [adVerification1],
-                                                     pixels: AdPixels(impression: [impression1]))
+                                                     pixels: AdPixels(impression: [impression1]),
+                                                     adProgress: [adProgress1])
         let initialResult = VRMParsingResult.Result(vastModel: .wrapper(wrapper))
         var sut = VRMParsingResult(parsedVASTs: [urlItem: initialResult])
         
         let secondWrapper = VRMCore.VASTModel.WrapperModel(tagURL: tag2URL,
                                                           adVerifications: [adVerification2],
-                                                          pixels: AdPixels(impression: [impression2]))
+                                                          pixels: AdPixels(impression: [impression2]),
+                                                          adProgress: [adProgress2])
         
         sut = reduce(state: sut, action: VRMCore.completeItemParsing(originalItem: urlItem,
                                                                      vastModel: .wrapper(secondWrapper)))
@@ -76,6 +82,7 @@ class VRMParsingResultComponentTest: XCTestCase {
             XCTAssertEqual(mergedWrapper.pixels.impression, [impression2, impression1])
             XCTAssertEqual(mergedWrapper.adVerifications, [adVerification2, adVerification1])
             XCTAssertEqual(mergedWrapper.tagURL, tag2URL)
+            XCTAssertEqual(mergedWrapper.adProgress, [adProgress2, adProgress1])
             
         } else {
             XCTFail()
@@ -85,7 +92,8 @@ class VRMParsingResultComponentTest: XCTestCase {
     func testInlineModelAfterWrappers() {
         let wrapper = VRMCore.VASTModel.WrapperModel(tagURL: tag1URL,
                                                      adVerifications: [adVerification2, adVerification1],
-                                                     pixels: AdPixels(impression: [impression2, impression1]))
+                                                     pixels: AdPixels(impression: [impression2, impression1]),
+                                                     adProgress: [adProgress2, adProgress1])
         
         let initialResult = VRMParsingResult.Result(vastModel: .wrapper(wrapper))
         var sut = VRMParsingResult(parsedVASTs: [urlItem: initialResult])
@@ -96,7 +104,7 @@ class VRMParsingResultComponentTest: XCTestCase {
                                   skipOffset: .none,
                                   clickthrough: nil,
                                   adParameters: nil,
-                                  adProgress: [],
+                                  adProgress: [adProgress3],
                                   pixels: AdPixels(impression: [impression3]),
                                   id: "")
         sut = reduce(state: sut, action: VRMCore.completeItemParsing(originalItem: urlItem,
@@ -107,6 +115,7 @@ class VRMParsingResultComponentTest: XCTestCase {
             XCTAssertNotEqual(result.id, initialResult.id)
             XCTAssertEqual(adModel.pixels.impression, [impression3, impression2, impression1])
             XCTAssertEqual(adModel.adVerifications, [adVerification3, adVerification2, adVerification1])
+            XCTAssertEqual(adModel.adProgress, [adProgress3, adProgress2, adProgress1])
             
         } else {
             XCTFail()


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Added ad progress into the wrapper model to correctly store tracking url and offset parsed from wrappers

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


