### PR TITLE
VPAID actions refactoring and updates for failover

### DIFF
--- a/PlayerCore/OpenMeasurement.swift
+++ b/PlayerCore/OpenMeasurement.swift
@@ -45,7 +45,7 @@ func reduce(state: OpenMeasurement, action: Action) -> OpenMeasurement {
          is SkipAd,
          is AdPlaybackFailed,
          is SelectVideoAtIdx,
-         is AdStartTimeout,
+         is MP4AdStartTimeout,
          is AdMaxShowTimeout:
         guard case .active(let adEvents, let videoEvents) = state else { return state }
         return .finished(adEvents, videoEvents)

--- a/PlayerCore/PlaybackBuffering.swift
+++ b/PlayerCore/PlaybackBuffering.swift
@@ -21,7 +21,7 @@ func reduce(state: PlaybackBuffering, action: Action) -> PlaybackBuffering {
         return PlaybackBuffering(content: .inactive, ad: state.ad)
     case is AdPlaybackBufferingInactive,
          is AdMaxShowTimeout,
-         is AdStartTimeout,
+         is MP4AdStartTimeout,
          is AdPlaybackFailed,
          is SkipAd,
          is ShowContent:

--- a/PlayerCore/action creators/AdStartTimeoutActionCreator.swift
+++ b/PlayerCore/action creators/AdStartTimeoutActionCreator.swift
@@ -1,6 +1,10 @@
 //  Copyright 2018, Oath Inc.
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 
-public func adStartTimeoutReached() -> Action {
-    return AdStartTimeout()
+public func mp4AdStartTimeoutReached() -> Action {
+    return MP4AdStartTimeout()
+}
+
+public func vpaidAdStartTimeoutReached() -> Action {
+    return VPAIDAdStartTimeout()
 }

--- a/PlayerCore/action creators/DropAd.swift
+++ b/PlayerCore/action creators/DropAd.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-public func dropAd(id: UUID) -> Action {
-    return DropAd(id: id)
+public func dropAd() -> Action {
+    return DropAd()
 }
 

--- a/PlayerCore/actions/AdKillAction.swift
+++ b/PlayerCore/actions/AdKillAction.swift
@@ -1,5 +1,6 @@
 //  Copyright 2018, Oath Inc.
 //  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
 
-struct AdStartTimeout: Action {}
+struct MP4AdStartTimeout: Action {}
+struct VPAIDAdStartTimeout: Action {}
 struct AdMaxShowTimeout: Action {}

--- a/PlayerCore/actions/DropAdAction.swift
+++ b/PlayerCore/actions/DropAdAction.swift
@@ -3,6 +3,4 @@
 
 import Foundation
 
-struct DropAd: Action {
-    let id: UUID
-}
+struct DropAd: Action {}

--- a/PlayerCore/actions/UpdateVPAIDAction.swift
+++ b/PlayerCore/actions/UpdateVPAIDAction.swift
@@ -46,5 +46,4 @@ enum VPAIDActions {
     struct AdUserMinimize: Action {}
     struct AdUserClose: Action {}
     struct AdScriptLoaded: Action {}
-    struct AdStartTimeout: Action {}
 }

--- a/PlayerCore/components/Ad.swift
+++ b/PlayerCore/components/Ad.swift
@@ -74,27 +74,42 @@ func reduce(state: Ad, action: Action) -> Ad {
                   currentAd: .play,
                   currentType: state.currentType)
         
-    case let action as DropAd:
-        return markIDAsPlayed(id: action.id)
-        
     case let action as VRMCore.VRMResponseFetchFailed:
         return markIDAsPlayed(id: action.requestID)
         
     case let action as VRMCore.NoGroupsToProcess:
-        return markIDAsPlayed(id: action.id)
+        var playedAds = state.playedAds
+        playedAds.insert(action.id)
+        return Ad(playedAds: playedAds,
+                  midrolls: state.midrolls,
+                  mp4AdCreative: nil,
+                  vpaidAdCreative: nil,
+                  currentAd: .empty,
+                  currentType: state.currentType)
         
     case let action as VRMCore.MaxSearchTimeout:
         return markIDAsPlayed(id: action.requestID)
         
+    case is VPAIDAdStartTimeout,
+         is VPAIDActions.AdError,
+         is VPAIDActions.AdNotSupported:
+        return Ad(playedAds: state.playedAds,
+                  midrolls: state.midrolls,
+                  mp4AdCreative: state.mp4AdCreative,
+                  vpaidAdCreative: nil,
+                  currentAd: state.currentAd,
+                  currentType: state.currentType)
+        
     case is ShowContent,
          is SkipAd,
+         is DropAd,
          is AdPlaybackFailed,
-         is VPAIDActions.AdError,
-         is AdStartTimeout,
+         is MP4AdStartTimeout,
          is AdMaxShowTimeout,
+         is VRMCore.NoGroupsToProcess,
+         is VRMCore.MaxSearchTimeout,
          is VPAIDActions.AdStopped,
-         is VPAIDActions.AdSkipped,
-         is VPAIDActions.AdNotSupported:
+         is VPAIDActions.AdSkipped:
         return Ad(playedAds: state.playedAds,
                   midrolls: state.midrolls,
                   mp4AdCreative: state.mp4AdCreative,

--- a/PlayerCore/components/AdCreative.swift
+++ b/PlayerCore/components/AdCreative.swift
@@ -7,6 +7,15 @@ public enum AdCreative: Hashable {
     case vpaid([VPAID])
     case none
     
+    public var isVPAID: Bool {
+        guard case .vpaid = self else { return false }
+        return true
+    }
+    public var isMP4: Bool {
+        guard case .mp4 = self else { return false }
+        return true
+    }
+    
     public struct MP4: Hashable {
         public let internalID: UUID
         public let url: URL

--- a/PlayerCore/components/AdFinishTracker.swift
+++ b/PlayerCore/components/AdFinishTracker.swift
@@ -17,7 +17,7 @@ func reduce(state: AdFinishTracker, action: Action) -> AdFinishTracker {
         return .unknown
     case is DropAd, is VRMCore.VRMResponseFetchFailed,
          is VPAIDActions.AdSkipped, is VPAIDActions.AdStopped,
-         is AdStartTimeout, is AdMaxShowTimeout,
+         is MP4AdStartTimeout, is AdMaxShowTimeout,
          is VRMCore.NoGroupsToProcess, is VRMCore.MaxSearchTimeout:
         return .forceFinished
     case is ShowContent:

--- a/PlayerCore/components/AdKill.swift
+++ b/PlayerCore/components/AdKill.swift
@@ -9,13 +9,16 @@ public enum AdKill {
 
 func reduce(state: AdKill, action: Action) -> AdKill {
     switch action {
-    case is AdStartTimeout:
+    case is MP4AdStartTimeout,
+         is VPAIDAdStartTimeout:
         return .adStartTimeout
     case is AdMaxShowTimeout:
         return .maxShowTime
     case is ShowContent,
          is SkipAd,
          is AdPlaybackFailed,
+         is VRMCore.SelectFinalResult,
+         is VRMCore.NoGroupsToProcess,
          is VPAIDActions.AdError,
          is VPAIDActions.AdStopped,
          is VPAIDActions.AdSkipped,

--- a/PlayerCore/components/Duration.swift
+++ b/PlayerCore/components/Duration.swift
@@ -21,7 +21,7 @@ func reduce(state: Duration, action: Action) -> Duration {
     case is DropAd,
          is ShowContent,
          is SkipAd,
-         is AdStartTimeout,
+         is MP4AdStartTimeout,
          is AdMaxShowTimeout,
          is VPAIDActions.AdStopped,
          is VPAIDActions.AdError,

--- a/PlayerCore/components/MP4AdBufferingTime.swift
+++ b/PlayerCore/components/MP4AdBufferingTime.swift
@@ -18,7 +18,7 @@ func reduce(state: MP4AdBufferingTime, action: Action) -> MP4AdBufferingTime {
         return MP4AdBufferingTime(status: .finished(startAt: startAt, finishAt: Date()))
         case is AdPlaybackFailed,
              is VRMCore.AdRequest,
-             is AdStartTimeout:
+             is MP4AdStartTimeout:
         return MP4AdBufferingTime(status: .empty)
     default:
         return state

--- a/PlayerCore/components/New VRM Core/VRMFinalResult.swift
+++ b/PlayerCore/components/New VRM Core/VRMFinalResult.swift
@@ -27,7 +27,8 @@ func reduce(state: VRMFinalResult, action: Action) -> VRMFinalResult {
         return .selected( result: .init(item: finalResult.item,
                                         inlineVAST: finalResult.inlineVAST))
     case is AdPlaybackFailed,
-         is AdStartTimeout,
+         is MP4AdStartTimeout,
+         is VPAIDAdStartTimeout,
          is VPAIDActions.AdError,
          is VPAIDActions.AdNotSupported:
         guard let result = state.successResult else { return state }

--- a/PlayerCore/components/Rate.swift
+++ b/PlayerCore/components/Rate.swift
@@ -132,6 +132,14 @@ func reduce(state: Rate, action: Action) -> Rate {
                     adRate: state.adRate,
                     isAttachedToViewPort: false,
                     currentKind: state.currentKind)
+        
+    case (is VRMCore.NoGroupsToProcess, .ad) where state.isAttachedToViewPort:
+        return Rate(contentRate: .init(player: true,
+                                       stream: state.contentRate.stream),
+                    adRate: .init(player: false,
+                                  stream: false),
+                    isAttachedToViewPort: state.isAttachedToViewPort,
+                    currentKind: .content)
    
     case (is VPAIDActions.AdStarted, .ad) where state.isAttachedToViewPort:
         return Rate(contentRate: .init(player: false, stream: false),
@@ -169,7 +177,7 @@ func reduce(state: Rate, action: Action) -> Rate {
          (is VPAIDActions.AdSkipped, .ad),
          (is VPAIDActions.AdError, .ad),
          (is SkipAd, .ad),
-         (is AdStartTimeout, .ad),
+         (is MP4AdStartTimeout, .ad),
          (is AdMaxShowTimeout, .ad):
         return Rate(contentRate: .init(player: true,
                                        stream: state.contentRate.stream),

--- a/PlayerCoreTests/Components/AdComponentTestCase.swift
+++ b/PlayerCoreTests/Components/AdComponentTestCase.swift
@@ -15,10 +15,7 @@ class AdComponentTestCase: XCTestCase {
                          currentAd: .empty,
                          currentType: .preroll)
         
-        var sut = reduce(state: initial, action: dropAd(id: id))
-        XCTAssertEqual(sut.playedAds.count, 1)
-        
-        sut = reduce(state: initial, action: VRMCore.adResponseFetchFailed(requestID: id))
+        var sut = reduce(state: initial, action: VRMCore.adResponseFetchFailed(requestID: id))
         XCTAssertEqual(sut.playedAds.count, 1)
         
         sut = reduce(state: initial, action: VRMCore.noGroupsToProcess(id: id))
@@ -80,6 +77,20 @@ class AdComponentTestCase: XCTestCase {
         let sut = reduce(state: initial, action: SelectVideoAtIdx(idx: 0, id: .init(), hasPrerollAds: true, midrolls: []))
         XCTAssertEqual(sut.currentAd, .empty)
         XCTAssertNil(sut.mp4AdCreative)
+    }
+    
+    func testVpaidAdStartTimeout() {
+        let vpaidAdCreative = AdCreative.vpaid(with: testUrl)
+        let initial = Ad(playedAds: [],
+                         midrolls: [],
+                         mp4AdCreative: AdCreative.mp4(with: testUrl),
+                         vpaidAdCreative: nil,
+                         currentAd: .play,
+                         currentType: .midroll)
+        var sut = reduce(state: initial, action: ShowVPAIDAd(creative: vpaidAdCreative, id: UUID()))
+        sut = reduce(state: sut, action: VPAIDAdStartTimeout())
+        XCTAssertEqual(sut.currentAd, .play)
+        XCTAssertNil(sut.vpaidAdCreative)
     }
     
     func testReduceDefaultCase() {

--- a/PlayerCoreTests/Components/AdKillTest.swift
+++ b/PlayerCoreTests/Components/AdKillTest.swift
@@ -7,7 +7,7 @@ import XCTest
 class AdKillTest: XCTestCase {
     
     func testStartTimeout() {
-        let sut = reduce(state: AdKill.none, action: AdStartTimeout())
+        let sut = reduce(state: AdKill.none, action: MP4AdStartTimeout())
         XCTAssertEqual(sut, .adStartTimeout)
     }
     

--- a/PlayerCoreTests/Components/DurationComponentTestCase.swift
+++ b/PlayerCoreTests/Components/DurationComponentTestCase.swift
@@ -26,7 +26,7 @@ class DurationComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.ad, nil)
         XCTAssertEqual(sut.content, CMTime.zero)
         
-        sut = reduce(state: sut, action: DropAd(id: UUID()))
+        sut = reduce(state: sut, action: DropAd())
         XCTAssertEqual(sut.ad, nil)
         XCTAssertEqual(sut.content, CMTime.zero)
         

--- a/PlayerCoreTests/Components/MP4AdBufferingTimeComponentTest.swift
+++ b/PlayerCoreTests/Components/MP4AdBufferingTimeComponentTest.swift
@@ -33,7 +33,7 @@ class MP4AdBufferingTimeComponentTest: XCTestCase {
         
         let actions: [PlayerCore.Action] = [AdPlaybackFailed(error: NSError(domain: "", code: 1, userInfo: nil)),
                                             VRMCore.AdRequest(url: url, id: UUID(), type: .preroll),
-                                            AdStartTimeout()]
+                                            MP4AdStartTimeout()]
         actions.forEach { action in
             let sut = reduce(state: initial, action: action)
             guard case .empty = sut.status else { XCTFail("on \(action) sut should be .empty, actual \(sut)"); return }

--- a/PlayerCoreTests/Components/RateComponentTestCase.swift
+++ b/PlayerCoreTests/Components/RateComponentTestCase.swift
@@ -240,5 +240,14 @@ class RateComponentTestCase: XCTestCase {
         XCTAssertEqual(sut.adRate.stream, false)
         XCTAssertEqual(sut.isAttachedToViewPort, true)
         XCTAssertEqual(sut.currentKind, .content)
+        
+        sut = reduce(state: sut, action: ShowMP4Ad(creative: AdCreative.mp4(with: testUrl), id: UUID()))
+        sut = reduce(state: sut, action: VRMCore.NoGroupsToProcess(id: UUID()))
+        XCTAssertEqual(sut.contentRate.player, true)
+        XCTAssertEqual(sut.contentRate.stream, false)
+        XCTAssertEqual(sut.adRate.player, false)
+        XCTAssertEqual(sut.adRate.stream, false)
+        XCTAssertEqual(sut.isAttachedToViewPort, true)
+        XCTAssertEqual(sut.currentKind, .content)
     }
 }

--- a/PlayerCoreTests/Components/VPAIDErrorsReducerTestCase.swift
+++ b/PlayerCoreTests/Components/VPAIDErrorsReducerTestCase.swift
@@ -72,7 +72,7 @@ class VPAIDErrorsReducerTest: XCTestCase {
         var state = initialState
         
         let actionsWhichClearState: [Action] = [
-            DropAd(id: UUID()),
+            DropAd(),
             VPAIDActions.AdStopped(),
             ShowContent(),
             SelectVideoAtIdx(idx: 1, id: UUID(), hasPrerollAds: true, midrolls: [])

--- a/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
+++ b/PlayerCoreTests/Components/VRMFinalResultComponentTest.swift
@@ -36,10 +36,12 @@ class VRMFinalResultComponentTest: XCTestCase {
         XCTAssertNotNil(emptySut.failedResult)
         XCTAssertEqual(emptySut, .failed(result: result))
         
-        emptySut = reduce(state: sut, action: AdStartTimeout())
+        emptySut = reduce(state: sut, action: MP4AdStartTimeout())
         XCTAssertNil(emptySut.successResult)
         XCTAssertNotNil(emptySut.failedResult)
         XCTAssertEqual(emptySut, .failed(result: result))
+        
+        
         
         emptySut = reduce(state: sut, action: VPAIDActions.AdNotSupported())
         XCTAssertNil(emptySut.successResult)


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- Added `AdStartTimeout` action in action creator for `vpaid` ads.
- Added handling of all vpaid errors (except JSEvaluation as the ad may still be playable).

So now, when we will get an error or start timeout for vpaid, we will move on to the next item and so on, until there won't be any items to try.

## Note
As far as I know, web player has failover for mp4 videos. To implement failover in our SDK, it will be enough to handle common actions in our SDK for mp4 videos (playbackFailed, start timeout and so on).

@VerizonAdPlatforms/mobile-sdk-developers: Please review.


